### PR TITLE
fix: resolve golangci-lint v2 issues

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "allowedTools": [
+    "Bash(golangci-lint:*)"
+  ]
+}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,23 +1,22 @@
+version: "2"
+
 linters:
   enable:
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
     - unused
+    - misspell
+
+formatters:
+  enable:
     - gofmt
     - goimports
-    - misspell
-    - revive
-
-linters-settings:
-  revive:
-    rules:
-      - name: exported
-        disabled: false
-  goimports:
-    local-prefixes: github.com/rianjs/confluence-cli
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/rianjs/confluence-cli
 
 run:
   timeout: 5m

--- a/api/attachments.go
+++ b/api/attachments.go
@@ -77,7 +77,7 @@ func (c *Client) DownloadAttachment(ctx context.Context, attachmentID string) (i
 
 	// Create a client that doesn't follow redirects
 	noRedirectClient := &http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
 	}
@@ -96,7 +96,7 @@ func (c *Client) DownloadAttachment(ctx context.Context, attachmentID string) (i
 	// Handle redirect
 	if resp.StatusCode == http.StatusFound || resp.StatusCode == http.StatusTemporaryRedirect {
 		redirectURL := resp.Header.Get("Location")
-		resp.Body.Close()
+		_ = resp.Body.Close()
 
 		// If redirect is relative, make it absolute
 		if redirectURL[0] == '/' {
@@ -116,7 +116,7 @@ func (c *Client) DownloadAttachment(ctx context.Context, attachmentID string) (i
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		return nil, fmt.Errorf("download failed with status %d", resp.StatusCode)
 	}
 
@@ -165,7 +165,7 @@ func (c *Client) UploadAttachment(ctx context.Context, pageID, filename string, 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/api/attachments_test.go
+++ b/api/attachments_test.go
@@ -18,7 +18,7 @@ func TestClient_ListAttachments(t *testing.T) {
 		assert.Equal(t, "GET", r.Method)
 
 		w.WriteHeader(http.StatusOK)
-		w.Write(testData)
+		_, _ = w.Write(testData)
 	}))
 	defer server.Close()
 
@@ -42,7 +42,7 @@ func TestClient_ListAttachments_WithOptions(t *testing.T) {
 		assert.Equal(t, "image/png", r.URL.Query().Get("mediaType"))
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"results": []}`))
+		_, _ = w.Write([]byte(`{"results": []}`))
 	}))
 	defer server.Close()
 
@@ -61,7 +61,7 @@ func TestClient_GetAttachment(t *testing.T) {
 		assert.Equal(t, "GET", r.Method)
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{
+		_, _ = w.Write([]byte(`{
 			"id": "att111",
 			"title": "screenshot.png",
 			"mediaType": "image/png",
@@ -94,7 +94,7 @@ func TestClient_DownloadAttachment(t *testing.T) {
 		if r.URL.Path == "/download/attachments/98765/screenshot.png" {
 			w.Header().Set("Content-Type", "image/png")
 			w.WriteHeader(http.StatusOK)
-			w.Write(fileContent)
+			_, _ = w.Write(fileContent)
 			return
 		}
 
@@ -105,7 +105,7 @@ func TestClient_DownloadAttachment(t *testing.T) {
 	client := NewClient(server.URL, "user@example.com", "token")
 	reader, err := client.DownloadAttachment(context.Background(), "att111")
 	require.NoError(t, err)
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 
 	// Read and verify content
 	buf := make([]byte, 100)

--- a/api/client.go
+++ b/api/client.go
@@ -1,3 +1,4 @@
+// Package api provides a client for the Confluence REST API.
 package api
 
 import (
@@ -67,7 +68,7 @@ func (c *Client) do(ctx context.Context, method, path string, body interface{}) 
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -27,7 +27,7 @@ func TestClient_AuthHeader(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		capturedAuth = r.Header.Get("Authorization")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{}`))
 	}))
 	defer server.Close()
 
@@ -49,7 +49,7 @@ func TestClient_Headers(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		capturedHeaders = r.Header.Clone()
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{}`))
 	}))
 	defer server.Close()
 
@@ -102,9 +102,9 @@ func TestClient_ErrorResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(tt.statusCode)
-				w.Write([]byte(tt.responseBody))
+				_, _ = w.Write([]byte(tt.responseBody))
 			}))
 			defer server.Close()
 
@@ -118,7 +118,7 @@ func TestClient_ErrorResponse(t *testing.T) {
 }
 
 func TestClient_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		// Slow response
 		<-r.Context().Done()
 	}))
@@ -139,7 +139,7 @@ func TestClient_URLConstruction(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		capturedPath = r.URL.Path
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{}`))
 	}))
 	defer server.Close()
 

--- a/api/pages_test.go
+++ b/api/pages_test.go
@@ -21,7 +21,7 @@ func TestClient_ListPages(t *testing.T) {
 		assert.Equal(t, "25", r.URL.Query().Get("limit"))
 
 		w.WriteHeader(http.StatusOK)
-		w.Write(testData)
+		_, _ = w.Write(testData)
 	}))
 	defer server.Close()
 
@@ -46,7 +46,7 @@ func TestClient_ListPages_WithOptions(t *testing.T) {
 		assert.Equal(t, "title", r.URL.Query().Get("sort"))
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"results": []}`))
+		_, _ = w.Write([]byte(`{"results": []}`))
 	}))
 	defer server.Close()
 
@@ -68,7 +68,7 @@ func TestClient_GetPage(t *testing.T) {
 		assert.Equal(t, "GET", r.Method)
 
 		w.WriteHeader(http.StatusOK)
-		w.Write(testData)
+		_, _ = w.Write(testData)
 	}))
 	defer server.Close()
 
@@ -90,7 +90,7 @@ func TestClient_GetPage_WithBodyFormat(t *testing.T) {
 		assert.Equal(t, "storage", r.URL.Query().Get("body-format"))
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"id": "98765", "title": "Test"}`))
+		_, _ = w.Write([]byte(`{"id": "98765", "title": "Test"}`))
 	}))
 	defer server.Close()
 
@@ -119,7 +119,7 @@ func TestClient_CreatePage(t *testing.T) {
 		assert.Equal(t, "<p>Content</p>", req.Body.Storage.Value)
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{
+		_, _ = w.Write([]byte(`{
 			"id": "99999",
 			"title": "New Page",
 			"spaceId": "123456",
@@ -163,7 +163,7 @@ func TestClient_UpdatePage(t *testing.T) {
 		assert.Equal(t, 6, req.Version.Number)
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{
+		_, _ = w.Write([]byte(`{
 			"id": "98765",
 			"title": "Updated Title",
 			"version": {"number": 6}

--- a/api/spaces_test.go
+++ b/api/spaces_test.go
@@ -30,7 +30,7 @@ func TestClient_ListSpaces(t *testing.T) {
 		assert.Equal(t, "25", r.URL.Query().Get("limit"))
 
 		w.WriteHeader(http.StatusOK)
-		w.Write(testData)
+		_, _ = w.Write(testData)
 	}))
 	defer server.Close()
 
@@ -56,7 +56,7 @@ func TestClient_ListSpaces_WithOptions(t *testing.T) {
 		assert.Equal(t, "current", r.URL.Query().Get("status"))
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"results": []}`))
+		_, _ = w.Write([]byte(`{"results": []}`))
 	}))
 	defer server.Close()
 
@@ -76,7 +76,7 @@ func TestClient_GetSpace(t *testing.T) {
 		assert.Equal(t, "GET", r.Method)
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{
+		_, _ = w.Write([]byte(`{
 			"id": "123456",
 			"key": "DEV",
 			"name": "Development",
@@ -95,9 +95,9 @@ func TestClient_GetSpace(t *testing.T) {
 }
 
 func TestClient_GetSpace_NotFound(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte(`{"message": "Space not found"}`))
+		_, _ = w.Write([]byte(`{"message": "Space not found"}`))
 	}))
 	defer server.Close()
 

--- a/cmd/cfl/main.go
+++ b/cmd/cfl/main.go
@@ -1,3 +1,4 @@
+// Package main is the entry point for the cfl CLI.
 package main
 
 import (

--- a/internal/cmd/attachment/download.go
+++ b/internal/cmd/attachment/download.go
@@ -76,14 +76,14 @@ func runDownload(attachmentID string, opts *downloadOptions) error {
 	if err != nil {
 		return fmt.Errorf("failed to download attachment: %w", err)
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 
 	// Create output file
 	outFile, err := os.Create(outputPath)
 	if err != nil {
 		return fmt.Errorf("failed to create output file: %w", err)
 	}
-	defer outFile.Close()
+	defer func() { _ = outFile.Close() }()
 
 	// Copy content
 	bytesWritten, err := io.Copy(outFile, reader)

--- a/internal/cmd/attachment/list.go
+++ b/internal/cmd/attachment/list.go
@@ -32,7 +32,7 @@ func NewCmdList() *cobra.Command {
 
   # List with custom limit
   cfl attachment list --page 12345 --limit 50`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			opts.output, _ = cmd.Flags().GetString("output")
 			opts.noColor, _ = cmd.Flags().GetBool("no-color")
 			return runList(opts)

--- a/internal/cmd/attachment/upload.go
+++ b/internal/cmd/attachment/upload.go
@@ -34,7 +34,7 @@ func NewCmdUpload() *cobra.Command {
 
   # Upload with a comment (-m for message/comment)
   cfl attachment upload --page 12345 --file image.png -m "Screenshot"`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			opts.output, _ = cmd.Flags().GetString("output")
 			opts.noColor, _ = cmd.Flags().GetBool("no-color")
 			return runUpload(opts)
@@ -67,7 +67,7 @@ func runUpload(opts *uploadOptions) error {
 	if err != nil {
 		return fmt.Errorf("failed to open file: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	// Get filename from path
 	filename := filepath.Base(opts.file)

--- a/internal/cmd/init/init.go
+++ b/internal/cmd/init/init.go
@@ -38,7 +38,7 @@ To generate an API token:
 
   # Pre-populate URL
   cfl init --url https://mycompany.atlassian.net`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return runInit(url, email, noVerify)
 		},
 	}
@@ -177,7 +177,7 @@ func verifyConnection(cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == 401 {
 		return fmt.Errorf("authentication failed - check your email and API token")

--- a/internal/cmd/page/create.go
+++ b/internal/cmd/page/create.go
@@ -63,7 +63,7 @@ Content format:
 
   # Create as child of another page
   cfl page create -s DEV -t "Child Page" --parent 12345`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			opts.output, _ = cmd.Flags().GetString("output")
 			opts.noColor, _ = cmd.Flags().GetBool("no-color")
 
@@ -241,13 +241,13 @@ Enter your content here using markdown.
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp file: %w", err)
 	}
-	defer os.Remove(tmpfile.Name())
+	defer func() { _ = os.Remove(tmpfile.Name()) }()
 
 	// Write initial content
 	if _, err := tmpfile.WriteString(template); err != nil {
 		return "", err
 	}
-	tmpfile.Close()
+	_ = tmpfile.Close()
 
 	// Get editor
 	editor := os.Getenv("EDITOR")

--- a/internal/cmd/page/edit.go
+++ b/internal/cmd/page/edit.go
@@ -277,13 +277,13 @@ func openEditorForEdit(existingPage *api.Page, isMarkdown bool) (string, error) 
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp file: %w", err)
 	}
-	defer os.Remove(tmpfile.Name())
+	defer func() { _ = os.Remove(tmpfile.Name()) }()
 
 	// Write existing content
 	if _, err := tmpfile.WriteString(editContent); err != nil {
 		return "", err
 	}
-	tmpfile.Close()
+	_ = tmpfile.Close()
 
 	// Get editor
 	editor := os.Getenv("EDITOR")

--- a/internal/cmd/page/list.go
+++ b/internal/cmd/page/list.go
@@ -37,7 +37,7 @@ func NewCmdList() *cobra.Command {
 
   # Output as JSON
   cfl page list -s DEV -o json`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			opts.output, _ = cmd.Flags().GetString("output")
 			opts.noColor, _ = cmd.Flags().GetBool("no-color")
 			return runList(opts)

--- a/internal/cmd/space/list.go
+++ b/internal/cmd/space/list.go
@@ -36,7 +36,7 @@ func NewCmdList() *cobra.Command {
 
   # Output as JSON
   cfl space list -o json`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Get global flags
 			opts.output, _ = cmd.Flags().GetString("output")
 			opts.noColor, _ = cmd.Flags().GetBool("no-color")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -124,17 +124,17 @@ func TestConfig_LoadFromEnv(t *testing.T) {
 
 	// Cleanup
 	defer func() {
-		os.Setenv("CFL_URL", origURL)
-		os.Setenv("CFL_EMAIL", origEmail)
-		os.Setenv("CFL_API_TOKEN", origToken)
-		os.Setenv("CFL_DEFAULT_SPACE", origSpace)
+		_ = os.Setenv("CFL_URL", origURL)
+		_ = os.Setenv("CFL_EMAIL", origEmail)
+		_ = os.Setenv("CFL_API_TOKEN", origToken)
+		_ = os.Setenv("CFL_DEFAULT_SPACE", origSpace)
 	}()
 
 	t.Run("loads all env vars", func(t *testing.T) {
-		os.Setenv("CFL_URL", "https://env.atlassian.net")
-		os.Setenv("CFL_EMAIL", "env@example.com")
-		os.Setenv("CFL_API_TOKEN", "env-token")
-		os.Setenv("CFL_DEFAULT_SPACE", "ENV")
+		_ = os.Setenv("CFL_URL", "https://env.atlassian.net")
+		_ = os.Setenv("CFL_EMAIL", "env@example.com")
+		_ = os.Setenv("CFL_API_TOKEN", "env-token")
+		_ = os.Setenv("CFL_DEFAULT_SPACE", "ENV")
 
 		cfg := &Config{}
 		cfg.LoadFromEnv()
@@ -146,10 +146,10 @@ func TestConfig_LoadFromEnv(t *testing.T) {
 	})
 
 	t.Run("env vars override existing values", func(t *testing.T) {
-		os.Setenv("CFL_URL", "https://override.atlassian.net")
-		os.Setenv("CFL_EMAIL", "")
-		os.Setenv("CFL_API_TOKEN", "")
-		os.Setenv("CFL_DEFAULT_SPACE", "")
+		_ = os.Setenv("CFL_URL", "https://override.atlassian.net")
+		_ = os.Setenv("CFL_EMAIL", "")
+		_ = os.Setenv("CFL_API_TOKEN", "")
+		_ = os.Setenv("CFL_DEFAULT_SPACE", "")
 
 		cfg := &Config{
 			URL:   "https://original.atlassian.net",

--- a/internal/view/view.go
+++ b/internal/view/view.go
@@ -14,6 +14,7 @@ import (
 // Format represents an output format.
 type Format string
 
+// Output format constants.
 const (
 	FormatTable Format = "table"
 	FormatJSON  Format = "json"
@@ -75,21 +76,21 @@ func (r *Renderer) RenderTable(headers []string, rows [][]string) {
 	// Print header
 	for i, h := range headers {
 		if i > 0 {
-			fmt.Fprint(r.writer, "  ")
+			_, _ = fmt.Fprint(r.writer, "  ")
 		}
-		fmt.Fprint(r.writer, h)
+		_, _ = fmt.Fprint(r.writer, h)
 	}
-	fmt.Fprintln(r.writer)
+	_, _ = fmt.Fprintln(r.writer)
 
 	// Print rows
 	for _, row := range rows {
 		for i, val := range row {
 			if i > 0 {
-				fmt.Fprint(r.writer, "  ")
+				_, _ = fmt.Fprint(r.writer, "  ")
 			}
-			fmt.Fprint(r.writer, val)
+			_, _ = fmt.Fprint(r.writer, val)
 		}
-		fmt.Fprintln(r.writer)
+		_, _ = fmt.Fprintln(r.writer)
 	}
 }
 
@@ -106,18 +107,18 @@ func (r *Renderer) renderTableAsJSON(headers []string, rows [][]string) {
 	}
 
 	data, _ := json.MarshalIndent(result, "", "  ")
-	fmt.Fprintln(r.writer, string(data))
+	_, _ = fmt.Fprintln(r.writer, string(data))
 }
 
-func (r *Renderer) renderTableAsPlain(headers []string, rows [][]string) {
+func (r *Renderer) renderTableAsPlain(_ []string, rows [][]string) {
 	for _, row := range rows {
 		for i, val := range row {
 			if i > 0 {
-				fmt.Fprint(r.writer, "\t")
+				_, _ = fmt.Fprint(r.writer, "\t")
 			}
-			fmt.Fprint(r.writer, val)
+			_, _ = fmt.Fprint(r.writer, val)
 		}
-		fmt.Fprintln(r.writer)
+		_, _ = fmt.Fprintln(r.writer)
 	}
 }
 
@@ -127,36 +128,36 @@ func (r *Renderer) RenderJSON(v interface{}) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(r.writer, string(data))
+	_, _ = fmt.Fprintln(r.writer, string(data))
 	return nil
 }
 
 // RenderText renders plain text.
 func (r *Renderer) RenderText(text string) {
-	fmt.Fprintln(r.writer, text)
+	_, _ = fmt.Fprintln(r.writer, text)
 }
 
 // RenderKeyValue renders a key-value pair.
 func (r *Renderer) RenderKeyValue(key, value string) {
 	if r.format == FormatJSON {
-		fmt.Fprintf(r.writer, `{"%s": "%s"}`+"\n", key, value)
+		_, _ = fmt.Fprintf(r.writer, `{"%s": "%s"}`+"\n", key, value)
 		return
 	}
 	bold := color.New(color.Bold)
-	bold.Fprintf(r.writer, "%s: ", key)
-	fmt.Fprintln(r.writer, value)
+	_, _ = bold.Fprintf(r.writer, "%s: ", key)
+	_, _ = fmt.Fprintln(r.writer, value)
 }
 
 // Success prints a success message.
 func (r *Renderer) Success(msg string) {
 	green := color.New(color.FgGreen)
-	green.Fprintln(r.writer, "✓ "+msg)
+	_, _ = green.Fprintln(r.writer, "✓ "+msg)
 }
 
 // Error prints an error message.
 func (r *Renderer) Error(msg string) {
 	red := color.New(color.FgRed)
-	red.Fprintln(r.writer, "✗ "+msg)
+	_, _ = red.Fprintln(r.writer, "✗ "+msg)
 }
 
 // Truncate truncates a string to the specified length.

--- a/pkg/md/converter.go
+++ b/pkg/md/converter.go
@@ -1,3 +1,4 @@
+// Package md provides markdown conversion utilities for Confluence.
 package md
 
 import (


### PR DESCRIPTION
Update .golangci.yml for golangci-lint v2 format and fix all lint issues:
- Move gofmt/goimports to formatters section
- Fix unchecked error returns (errcheck) with _ assignments
- Fix unused parameters by renaming to _
- Add missing package comments

## Summary

Brief description of changes.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (`go test ./...`)
- [ ] I have updated documentation if needed

## Related Issues

Fixes #(issue number)
