### PR TITLE
fix: resolve space key from spaceId for page copy

### DIFF
--- a/internal/cmd/page/copy.go
+++ b/internal/cmd/page/copy.go
@@ -75,14 +75,19 @@ func runCopy(pageID string, opts *copyOptions, client *api.Client) error {
 		client = api.NewClient(cfg.URL, cfg.Email, cfg.APIToken)
 	}
 
-	// If no destination space specified, get source page's space
+	// If no destination space specified, get source page's space key
 	destSpace := opts.space
 	if destSpace == "" {
 		sourcePage, err := client.GetPage(context.Background(), pageID, nil)
 		if err != nil {
 			return fmt.Errorf("failed to get source page: %w", err)
 		}
-		destSpace = sourcePage.SpaceID
+		// SpaceID is numeric (e.g., "3367829530"), but copy API needs space key
+		space, err := client.GetSpace(context.Background(), sourcePage.SpaceID)
+		if err != nil {
+			return fmt.Errorf("failed to get space: %w", err)
+		}
+		destSpace = space.Key
 	}
 
 	// Copy the page


### PR DESCRIPTION
## Summary
- Fix `page copy` without `--space` flag which was failing with "Destination space not found"
- The issue was that spaceId is numeric (e.g., "3367829530") but the copy API expects the space key (e.g., "confluence")
- Now fetches space details via GetSpace() to resolve the key

Fixes #14

## Test plan
- [x] Unit tests pass (including new test for GetSpace failure)
- [x] Manually tested: `./bin/cfl page copy 3367829866 --title "[Test] Copy"` now works without --space