### PR TITLE
test: add comprehensive command-layer tests

### DIFF
--- a/internal/cmd/attachment/list_test.go
+++ b/internal/cmd/attachment/list_test.go
@@ -1,0 +1,132 @@
+package attachment
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rianjs/confluence-cli/api"
+)
+
+func TestRunList_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"results": [
+				{"id": "att1", "title": "doc.pdf", "mediaType": "application/pdf", "fileSize": 1024},
+				{"id": "att2", "title": "image.png", "mediaType": "image/png", "fileSize": 2048}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		pageID:  "12345",
+		limit:   25,
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunList_Empty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"results": []}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		pageID:  "12345",
+		limit:   25,
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunList_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message": "Page not found"}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		pageID:  "99999",
+		limit:   25,
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list attachments")
+}
+
+func TestRunList_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"results": [
+				{"id": "att1", "title": "doc.pdf", "mediaType": "application/pdf", "fileSize": 1024}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		pageID:  "12345",
+		limit:   25,
+		output:  "json",
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunList_InvalidOutputFormat(t *testing.T) {
+	// Don't need a server - should fail before API call
+	client := api.NewClient("http://unused", "test@example.com", "token")
+	opts := &listOptions{
+		pageID:  "12345",
+		output:  "invalid",
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid output format")
+}
+
+func TestFormatFileSize(t *testing.T) {
+	tests := []struct {
+		bytes    int64
+		expected string
+	}{
+		{0, "0 B"},
+		{500, "500 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{1572864, "1.5 MB"},
+		{1073741824, "1.0 GB"},
+		{1610612736, "1.5 GB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := formatFileSize(tt.bytes)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/cmd/attachment/upload_test.go
+++ b/internal/cmd/attachment/upload_test.go
@@ -1,0 +1,153 @@
+package attachment
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rianjs/confluence-cli/api"
+)
+
+func TestRunUpload_Success(t *testing.T) {
+	// Create temp file to upload
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "upload.txt")
+	err := os.WriteFile(testFile, []byte("test content"), 0644)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Contains(t, r.URL.Path, "/child/attachment")
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"results": [{
+				"id": "att123",
+				"title": "upload.txt",
+				"mediaType": "text/plain",
+				"fileSize": 12
+			}]
+		}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &uploadOptions{
+		pageID:  "12345",
+		file:    testFile,
+		noColor: true,
+	}
+
+	err = runUpload(opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunUpload_WithComment(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "upload.txt")
+	err := os.WriteFile(testFile, []byte("test content"), 0644)
+	require.NoError(t, err)
+
+	var receivedComment string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := r.ParseMultipartForm(10 << 20)
+		require.NoError(t, err)
+		receivedComment = r.FormValue("comment")
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"results": [{
+				"id": "att123",
+				"title": "upload.txt",
+				"mediaType": "text/plain",
+				"fileSize": 12
+			}]
+		}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &uploadOptions{
+		pageID:  "12345",
+		file:    testFile,
+		comment: "My upload comment",
+		noColor: true,
+	}
+
+	err = runUpload(opts, client)
+	require.NoError(t, err)
+	assert.Equal(t, "My upload comment", receivedComment)
+}
+
+func TestRunUpload_FileNotFound(t *testing.T) {
+	client := api.NewClient("http://unused", "test@example.com", "token")
+	opts := &uploadOptions{
+		pageID:  "12345",
+		file:    "/nonexistent/file.txt",
+		noColor: true,
+	}
+
+	err := runUpload(opts, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to open file")
+}
+
+func TestRunUpload_APIError(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "upload.txt")
+	err := os.WriteFile(testFile, []byte("test content"), 0644)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"message": "Permission denied"}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &uploadOptions{
+		pageID:  "12345",
+		file:    testFile,
+		noColor: true,
+	}
+
+	err = runUpload(opts, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to upload attachment")
+}
+
+func TestRunUpload_JSONOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "upload.txt")
+	err := os.WriteFile(testFile, []byte("test content"), 0644)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"results": [{
+				"id": "att123",
+				"title": "upload.txt",
+				"mediaType": "text/plain",
+				"fileSize": 12
+			}]
+		}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &uploadOptions{
+		pageID:  "12345",
+		file:    testFile,
+		output:  "json",
+		noColor: true,
+	}
+
+	err = runUpload(opts, client)
+	require.NoError(t, err)
+}

--- a/internal/cmd/page/create_test.go
+++ b/internal/cmd/page/create_test.go
@@ -1,0 +1,344 @@
+package page
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rianjs/confluence-cli/api"
+)
+
+// mockCreateServer creates a test server that handles GetSpaceByKey and CreatePage requests
+func mockCreateServer(t *testing.T, spaceKey, spaceID string, createStatus int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces") && r.URL.Query().Get("keys") != "":
+			// GetSpaceByKey
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"results": [{"id": "` + spaceID + `", "key": "` + spaceKey + `", "name": "Test Space", "type": "global"}]}`))
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "/pages"):
+			// CreatePage
+			w.WriteHeader(createStatus)
+			if createStatus == http.StatusOK {
+				w.Write([]byte(`{
+					"id": "99999",
+					"title": "Test Page",
+					"spaceId": "` + spaceID + `",
+					"version": {"number": 1},
+					"_links": {"webui": "/spaces/` + spaceKey + `/pages/99999"}
+				}`))
+			} else {
+				w.Write([]byte(`{"message": "Create failed"}`))
+			}
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestRunCreate_Success(t *testing.T) {
+	// Create temp markdown file
+	tmpDir := t.TempDir()
+	mdFile := filepath.Join(tmpDir, "content.md")
+	err := os.WriteFile(mdFile, []byte("# Hello\n\nWorld"), 0644)
+	require.NoError(t, err)
+
+	server := mockCreateServer(t, "DEV", "123456", http.StatusOK)
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &createOptions{
+		space:   "DEV",
+		title:   "Test Page",
+		file:    mdFile,
+		noColor: true,
+	}
+
+	err = runCreate(opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunCreate_HTMLFile(t *testing.T) {
+	// Create temp HTML file - should be treated as storage format
+	tmpDir := t.TempDir()
+	htmlFile := filepath.Join(tmpDir, "content.html")
+	err := os.WriteFile(htmlFile, []byte("<p>Hello World</p>"), 0644)
+	require.NoError(t, err)
+
+	var receivedBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"results": [{"id": "123456", "key": "DEV"}]}`))
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "/pages"):
+			body, _ := io.ReadAll(r.Body)
+			json.Unmarshal(body, &receivedBody)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"id": "99999", "title": "Test", "version": {"number": 1}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &createOptions{
+		space:   "DEV",
+		title:   "Test Page",
+		file:    htmlFile,
+		noColor: true,
+	}
+
+	err = runCreate(opts, client)
+	require.NoError(t, err)
+
+	// Verify HTML was not converted (should be passed as-is)
+	bodyMap := receivedBody["body"].(map[string]interface{})
+	storageMap := bodyMap["storage"].(map[string]interface{})
+	content := storageMap["value"].(string)
+	assert.Equal(t, "<p>Hello World</p>", content)
+}
+
+func TestRunCreate_NoMarkdownFlag(t *testing.T) {
+	// Create temp file with markdown extension
+	tmpDir := t.TempDir()
+	mdFile := filepath.Join(tmpDir, "content.md")
+	err := os.WriteFile(mdFile, []byte("<p>Raw XHTML</p>"), 0644)
+	require.NoError(t, err)
+
+	var receivedBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"results": [{"id": "123456", "key": "DEV"}]}`))
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "/pages"):
+			body, _ := io.ReadAll(r.Body)
+			json.Unmarshal(body, &receivedBody)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"id": "99999", "title": "Test", "version": {"number": 1}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	useMd := false
+	opts := &createOptions{
+		space:    "DEV",
+		title:    "Test Page",
+		file:     mdFile,
+		markdown: &useMd, // Force no markdown conversion
+		noColor:  true,
+	}
+
+	err = runCreate(opts, client)
+	require.NoError(t, err)
+
+	// Verify content was not converted even though file has .md extension
+	bodyMap := receivedBody["body"].(map[string]interface{})
+	storageMap := bodyMap["storage"].(map[string]interface{})
+	content := storageMap["value"].(string)
+	assert.Equal(t, "<p>Raw XHTML</p>", content)
+}
+
+func TestRunCreate_MissingSpace(t *testing.T) {
+	tmpDir := t.TempDir()
+	mdFile := filepath.Join(tmpDir, "content.md")
+	err := os.WriteFile(mdFile, []byte("# Hello"), 0644)
+	require.NoError(t, err)
+
+	// Don't need server - should fail before API call
+	client := api.NewClient("http://unused", "test@example.com", "token")
+	opts := &createOptions{
+		space:   "", // No space provided
+		title:   "Test Page",
+		file:    mdFile,
+		noColor: true,
+	}
+
+	err = runCreate(opts, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "space is required")
+}
+
+func TestRunCreate_SpaceNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	mdFile := filepath.Join(tmpDir, "content.md")
+	err := os.WriteFile(mdFile, []byte("# Hello"), 0644)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return empty results for space lookup
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"results": []}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &createOptions{
+		space:   "INVALID",
+		title:   "Test Page",
+		file:    mdFile,
+		noColor: true,
+	}
+
+	err = runCreate(opts, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to find space")
+}
+
+func TestRunCreate_CreateFailed(t *testing.T) {
+	tmpDir := t.TempDir()
+	mdFile := filepath.Join(tmpDir, "content.md")
+	err := os.WriteFile(mdFile, []byte("# Hello"), 0644)
+	require.NoError(t, err)
+
+	server := mockCreateServer(t, "DEV", "123456", http.StatusForbidden)
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &createOptions{
+		space:   "DEV",
+		title:   "Test Page",
+		file:    mdFile,
+		noColor: true,
+	}
+
+	err = runCreate(opts, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create page")
+}
+
+func TestRunCreate_WithParent(t *testing.T) {
+	tmpDir := t.TempDir()
+	mdFile := filepath.Join(tmpDir, "content.md")
+	err := os.WriteFile(mdFile, []byte("# Child Page"), 0644)
+	require.NoError(t, err)
+
+	var receivedBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"results": [{"id": "123456", "key": "DEV"}]}`))
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "/pages"):
+			body, _ := io.ReadAll(r.Body)
+			json.Unmarshal(body, &receivedBody)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"id": "99999", "title": "Test", "version": {"number": 1}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &createOptions{
+		space:   "DEV",
+		title:   "Child Page",
+		parent:  "12345",
+		file:    mdFile,
+		noColor: true,
+	}
+
+	err = runCreate(opts, client)
+	require.NoError(t, err)
+
+	// Verify parent ID was included in request
+	assert.Equal(t, "12345", receivedBody["parentId"])
+}
+
+func TestRunCreate_JSONOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	mdFile := filepath.Join(tmpDir, "content.md")
+	err := os.WriteFile(mdFile, []byte("# Hello"), 0644)
+	require.NoError(t, err)
+
+	server := mockCreateServer(t, "DEV", "123456", http.StatusOK)
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &createOptions{
+		space:   "DEV",
+		title:   "Test Page",
+		file:    mdFile,
+		output:  "json",
+		noColor: true,
+	}
+
+	err = runCreate(opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunCreate_MarkdownConversion(t *testing.T) {
+	tmpDir := t.TempDir()
+	mdFile := filepath.Join(tmpDir, "content.md")
+	err := os.WriteFile(mdFile, []byte("# Hello World\n\nThis is **bold** text."), 0644)
+	require.NoError(t, err)
+
+	var receivedBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"results": [{"id": "123456", "key": "DEV"}]}`))
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "/pages"):
+			body, _ := io.ReadAll(r.Body)
+			json.Unmarshal(body, &receivedBody)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"id": "99999", "title": "Test", "version": {"number": 1}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &createOptions{
+		space:   "DEV",
+		title:   "Test Page",
+		file:    mdFile,
+		noColor: true,
+	}
+
+	err = runCreate(opts, client)
+	require.NoError(t, err)
+
+	// Verify markdown was converted to HTML
+	bodyMap := receivedBody["body"].(map[string]interface{})
+	storageMap := bodyMap["storage"].(map[string]interface{})
+	content := storageMap["value"].(string)
+
+	// Should have HTML heading and strong tag from markdown conversion
+	assert.Contains(t, content, "<h1")
+	assert.Contains(t, content, "<strong>bold</strong>")
+}
+
+func TestRunCreate_FileReadError(t *testing.T) {
+	server := mockCreateServer(t, "DEV", "123456", http.StatusOK)
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &createOptions{
+		space:   "DEV",
+		title:   "Test Page",
+		file:    "/nonexistent/file.md",
+		noColor: true,
+	}
+
+	err := runCreate(opts, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read file")
+}

--- a/internal/cmd/page/delete_test.go
+++ b/internal/cmd/page/delete_test.go
@@ -1,0 +1,225 @@
+package page
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rianjs/confluence-cli/api"
+)
+
+// mockPageServer creates a test server that handles GetPage and DeletePage requests
+func mockPageServer(t *testing.T, pageID, title string, deleteStatus int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/pages/"+pageID):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "` + pageID + `",
+				"title": "` + title + `",
+				"spaceId": "123456",
+				"version": {"number": 1}
+			}`))
+		case r.Method == "DELETE" && strings.Contains(r.URL.Path, "/pages/"+pageID):
+			w.WriteHeader(deleteStatus)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestRunDelete_ConfirmYes(t *testing.T) {
+	server := mockPageServer(t, "12345", "Test Page", http.StatusNoContent)
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &deleteOptions{
+		force:   false,
+		output:  "",
+		noColor: true,
+		stdin:   strings.NewReader("y\n"),
+	}
+
+	err := runDelete("12345", opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunDelete_ConfirmYesUppercase(t *testing.T) {
+	server := mockPageServer(t, "12345", "Test Page", http.StatusNoContent)
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &deleteOptions{
+		force:   false,
+		output:  "",
+		noColor: true,
+		stdin:   strings.NewReader("Y\n"),
+	}
+
+	err := runDelete("12345", opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunDelete_ConfirmNo(t *testing.T) {
+	server := mockPageServer(t, "12345", "Test Page", http.StatusNoContent)
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &deleteOptions{
+		force:   false,
+		output:  "",
+		noColor: true,
+		stdin:   strings.NewReader("n\n"),
+	}
+
+	err := runDelete("12345", opts, client)
+	require.NoError(t, err) // Cancellation is not an error
+}
+
+func TestRunDelete_ConfirmEmpty(t *testing.T) {
+	server := mockPageServer(t, "12345", "Test Page", http.StatusNoContent)
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &deleteOptions{
+		force:   false,
+		output:  "",
+		noColor: true,
+		stdin:   strings.NewReader("\n"),
+	}
+
+	err := runDelete("12345", opts, client)
+	require.NoError(t, err) // Empty input should cancel
+}
+
+func TestRunDelete_ConfirmOther(t *testing.T) {
+	server := mockPageServer(t, "12345", "Test Page", http.StatusNoContent)
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &deleteOptions{
+		force:   false,
+		output:  "",
+		noColor: true,
+		stdin:   strings.NewReader("maybe\n"),
+	}
+
+	err := runDelete("12345", opts, client)
+	require.NoError(t, err) // Any non-y/Y input should cancel
+}
+
+func TestRunDelete_Force(t *testing.T) {
+	server := mockPageServer(t, "12345", "Test Page", http.StatusNoContent)
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &deleteOptions{
+		force:   true,
+		output:  "",
+		noColor: true,
+		stdin:   nil, // stdin not used when force=true
+	}
+
+	err := runDelete("12345", opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunDelete_PageNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message": "Page not found"}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &deleteOptions{
+		force:   true,
+		output:  "",
+		noColor: true,
+	}
+
+	err := runDelete("99999", opts, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get page")
+}
+
+func TestRunDelete_DeleteFailed(t *testing.T) {
+	server := mockPageServer(t, "12345", "Test Page", http.StatusForbidden)
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &deleteOptions{
+		force:   true,
+		output:  "",
+		noColor: true,
+	}
+
+	err := runDelete("12345", opts, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete page")
+}
+
+func TestRunDelete_JSONOutput(t *testing.T) {
+	server := mockPageServer(t, "12345", "Test Page", http.StatusNoContent)
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &deleteOptions{
+		force:   true,
+		output:  "json",
+		noColor: true,
+	}
+
+	err := runDelete("12345", opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunDelete_ConfirmationInputs(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		shouldProceed bool
+	}{
+		{"lowercase y", "y\n", true},
+		{"uppercase Y", "Y\n", true},
+		{"lowercase n", "n\n", false},
+		{"uppercase N", "N\n", false},
+		{"empty input", "\n", false},
+		{"other input", "yes\n", false},
+		{"whitespace", "  \n", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Track if delete was called
+			deleteCalled := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == "DELETE" {
+					deleteCalled = true
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+				// GET request for page info
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"id": "12345", "title": "Test", "version": {"number": 1}}`))
+			}))
+			defer server.Close()
+
+			client := api.NewClient(server.URL, "test@example.com", "token")
+			opts := &deleteOptions{
+				force:   false,
+				noColor: true,
+				stdin:   strings.NewReader(tt.input),
+			}
+
+			err := runDelete("12345", opts, client)
+			require.NoError(t, err)
+			assert.Equal(t, tt.shouldProceed, deleteCalled, "delete should have been called: %v", tt.shouldProceed)
+		})
+	}
+}

--- a/internal/cmd/page/edit_test.go
+++ b/internal/cmd/page/edit_test.go
@@ -1,0 +1,395 @@
+package page
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rianjs/confluence-cli/api"
+)
+
+func TestRunEdit_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	mdFile := filepath.Join(tmpDir, "content.md")
+	err := os.WriteFile(mdFile, []byte("# Updated Content\n\nNew text here."), 0644)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/pages/12345"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "12345",
+				"title": "Test Page",
+				"version": {"number": 5},
+				"body": {"storage": {"value": "<p>Old</p>"}},
+				"_links": {"webui": "/pages/12345"}
+			}`))
+		case r.Method == "PUT" && strings.Contains(r.URL.Path, "/pages/12345"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "12345",
+				"title": "Test Page",
+				"version": {"number": 6},
+				"_links": {"webui": "/pages/12345"}
+			}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &editOptions{
+		pageID:  "12345",
+		file:    mdFile,
+		noColor: true,
+	}
+
+	err = runEdit(opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunEdit_TitleOnly(t *testing.T) {
+	var receivedBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/pages/12345"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "12345",
+				"title": "Old Title",
+				"version": {"number": 3},
+				"body": {"storage": {"representation": "storage", "value": "<p>Keep this</p>"}},
+				"_links": {"webui": "/pages/12345"}
+			}`))
+		case r.Method == "PUT" && strings.Contains(r.URL.Path, "/pages/12345"):
+			body, _ := io.ReadAll(r.Body)
+			json.Unmarshal(body, &receivedBody)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "12345",
+				"title": "New Title",
+				"version": {"number": 4},
+				"_links": {"webui": "/pages/12345"}
+			}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &editOptions{
+		pageID:  "12345",
+		title:   "New Title",
+		noColor: true,
+	}
+
+	// Note: Without file input and with a title, the current implementation
+	// will still try to open an editor. For this test to work properly,
+	// we need to provide a file to avoid the editor path.
+	tmpDir := t.TempDir()
+	mdFile := filepath.Join(tmpDir, "content.md")
+	err := os.WriteFile(mdFile, []byte("<p>Keep this</p>"), 0644)
+	require.NoError(t, err)
+
+	useMd := false
+	opts.file = mdFile
+	opts.markdown = &useMd
+
+	err = runEdit(opts, client)
+	require.NoError(t, err)
+
+	// Verify title was changed
+	assert.Equal(t, "New Title", receivedBody["title"])
+}
+
+func TestRunEdit_PageNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message": "Page not found"}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &editOptions{
+		pageID:  "99999",
+		title:   "New Title",
+		noColor: true,
+	}
+
+	err := runEdit(opts, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get page")
+}
+
+func TestRunEdit_UpdateFailed(t *testing.T) {
+	tmpDir := t.TempDir()
+	mdFile := filepath.Join(tmpDir, "content.md")
+	err := os.WriteFile(mdFile, []byte("# New Content"), 0644)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "12345",
+				"title": "Test",
+				"version": {"number": 1},
+				"body": {"storage": {"value": "<p>Old</p>"}},
+				"_links": {"webui": "/pages/12345"}
+			}`))
+		case "PUT":
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(`{"message": "Permission denied"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &editOptions{
+		pageID:  "12345",
+		file:    mdFile,
+		noColor: true,
+	}
+
+	err = runEdit(opts, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update page")
+}
+
+func TestRunEdit_VersionIncrement(t *testing.T) {
+	tmpDir := t.TempDir()
+	mdFile := filepath.Join(tmpDir, "content.md")
+	err := os.WriteFile(mdFile, []byte("# Updated"), 0644)
+	require.NoError(t, err)
+
+	var receivedVersion int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "12345",
+				"title": "Test",
+				"version": {"number": 7},
+				"body": {"storage": {"value": "<p>Old</p>"}},
+				"_links": {"webui": "/pages/12345"}
+			}`))
+		case "PUT":
+			body, _ := io.ReadAll(r.Body)
+			var req map[string]interface{}
+			json.Unmarshal(body, &req)
+			if v, ok := req["version"].(map[string]interface{}); ok {
+				receivedVersion = int(v["number"].(float64))
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "12345",
+				"title": "Test",
+				"version": {"number": 8},
+				"_links": {"webui": "/pages/12345"}
+			}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &editOptions{
+		pageID:  "12345",
+		file:    mdFile,
+		noColor: true,
+	}
+
+	err = runEdit(opts, client)
+	require.NoError(t, err)
+
+	// Verify version was incremented from 7 to 8
+	assert.Equal(t, 8, receivedVersion)
+}
+
+func TestRunEdit_HTMLFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	htmlFile := filepath.Join(tmpDir, "content.html")
+	err := os.WriteFile(htmlFile, []byte("<p>Direct HTML</p>"), 0644)
+	require.NoError(t, err)
+
+	var receivedBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "12345",
+				"title": "Test",
+				"version": {"number": 1},
+				"body": {"storage": {"value": "<p>Old</p>"}},
+				"_links": {"webui": "/pages/12345"}
+			}`))
+		case "PUT":
+			body, _ := io.ReadAll(r.Body)
+			json.Unmarshal(body, &receivedBody)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "12345",
+				"title": "Test",
+				"version": {"number": 2},
+				"_links": {"webui": "/pages/12345"}
+			}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &editOptions{
+		pageID:  "12345",
+		file:    htmlFile,
+		noColor: true,
+	}
+
+	err = runEdit(opts, client)
+	require.NoError(t, err)
+
+	// Verify HTML was not converted
+	bodyMap := receivedBody["body"].(map[string]interface{})
+	storageMap := bodyMap["storage"].(map[string]interface{})
+	content := storageMap["value"].(string)
+	assert.Equal(t, "<p>Direct HTML</p>", content)
+}
+
+func TestRunEdit_NoMarkdownFlag(t *testing.T) {
+	tmpDir := t.TempDir()
+	mdFile := filepath.Join(tmpDir, "content.md")
+	err := os.WriteFile(mdFile, []byte("<p>Raw XHTML in .md file</p>"), 0644)
+	require.NoError(t, err)
+
+	var receivedBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "12345",
+				"title": "Test",
+				"version": {"number": 1},
+				"body": {"storage": {"value": "<p>Old</p>"}},
+				"_links": {"webui": "/pages/12345"}
+			}`))
+		case "PUT":
+			body, _ := io.ReadAll(r.Body)
+			json.Unmarshal(body, &receivedBody)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "12345",
+				"title": "Test",
+				"version": {"number": 2},
+				"_links": {"webui": "/pages/12345"}
+			}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	useMd := false
+	opts := &editOptions{
+		pageID:   "12345",
+		file:     mdFile,
+		markdown: &useMd,
+		noColor:  true,
+	}
+
+	err = runEdit(opts, client)
+	require.NoError(t, err)
+
+	// Verify content was not converted
+	bodyMap := receivedBody["body"].(map[string]interface{})
+	storageMap := bodyMap["storage"].(map[string]interface{})
+	content := storageMap["value"].(string)
+	assert.Equal(t, "<p>Raw XHTML in .md file</p>", content)
+}
+
+func TestRunEdit_JSONOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	mdFile := filepath.Join(tmpDir, "content.md")
+	err := os.WriteFile(mdFile, []byte("# Updated"), 0644)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "12345",
+				"title": "Test",
+				"version": {"number": 1},
+				"body": {"storage": {"value": "<p>Old</p>"}},
+				"_links": {"webui": "/pages/12345"}
+			}`))
+		case "PUT":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "12345",
+				"title": "Test",
+				"version": {"number": 2},
+				"_links": {"webui": "/pages/12345"}
+			}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &editOptions{
+		pageID:  "12345",
+		file:    mdFile,
+		output:  "json",
+		noColor: true,
+	}
+
+	err = runEdit(opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunEdit_FileReadError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"id": "12345",
+			"title": "Test",
+			"version": {"number": 1},
+			"body": {"storage": {"value": "<p>Old</p>"}},
+			"_links": {"webui": "/pages/12345"}
+		}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &editOptions{
+		pageID:  "12345",
+		file:    "/nonexistent/file.md",
+		noColor: true,
+	}
+
+	err := runEdit(opts, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read file")
+}

--- a/internal/cmd/page/list_test.go
+++ b/internal/cmd/page/list_test.go
@@ -1,0 +1,253 @@
+package page
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rianjs/confluence-cli/api"
+)
+
+// mockListServer creates a test server for page list operations
+// It handles both GetSpaceByKey and ListPages endpoints
+func mockListServer(t *testing.T, spaceKey, spaceID string, pages string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces") && r.URL.Query().Get("keys") != "":
+			// GetSpaceByKey
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"results": [{"id": "` + spaceID + `", "key": "` + spaceKey + `", "name": "Test Space", "type": "global"}]
+			}`))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces/"+spaceID+"/pages"):
+			// ListPages
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(pages))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestRunList_PageList_Success(t *testing.T) {
+	server := mockListServer(t, "DEV", "123456", `{
+		"results": [
+			{"id": "11111", "title": "Page One", "status": "current", "version": {"number": 1}},
+			{"id": "22222", "title": "Page Two", "status": "current", "version": {"number": 5}}
+		]
+	}`)
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		space:   "DEV",
+		limit:   25,
+		status:  "current",
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunList_PageList_EmptyResults(t *testing.T) {
+	server := mockListServer(t, "DEV", "123456", `{"results": []}`)
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		space:   "DEV",
+		limit:   25,
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunList_PageList_JSONOutput(t *testing.T) {
+	server := mockListServer(t, "DEV", "123456", `{
+		"results": [
+			{"id": "11111", "title": "Page One", "status": "current", "version": {"number": 1}}
+		]
+	}`)
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		space:   "DEV",
+		limit:   25,
+		output:  "json",
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunList_PageList_InvalidOutputFormat(t *testing.T) {
+	opts := &listOptions{
+		space:   "DEV",
+		limit:   25,
+		output:  "invalid",
+		noColor: true,
+	}
+
+	err := runList(opts, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid output format")
+}
+
+func TestRunList_PageList_NegativeLimit(t *testing.T) {
+	opts := &listOptions{
+		space:   "DEV",
+		limit:   -1,
+		noColor: true,
+	}
+
+	err := runList(opts, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid limit")
+}
+
+func TestRunList_PageList_ZeroLimit(t *testing.T) {
+	opts := &listOptions{
+		space:   "DEV",
+		limit:   0,
+		noColor: true,
+	}
+
+	// Zero limit should return empty without making API call
+	err := runList(opts, nil)
+	require.NoError(t, err)
+}
+
+func TestRunList_PageList_MissingSpace(t *testing.T) {
+	// Create a mock client to avoid config loading
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		space:   "", // No space provided
+		limit:   25,
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "space is required")
+}
+
+func TestRunList_PageList_SpaceNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return empty results for space lookup
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"results": []}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		space:   "INVALID",
+		limit:   25,
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to find space")
+}
+
+func TestRunList_PageList_NullVersion(t *testing.T) {
+	server := mockListServer(t, "DEV", "123456", `{
+		"results": [
+			{"id": "11111", "title": "Page Without Version", "status": "current", "version": null}
+		]
+	}`)
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		space:   "DEV",
+		limit:   25,
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunList_PageList_HasMore(t *testing.T) {
+	server := mockListServer(t, "DEV", "123456", `{
+		"results": [
+			{"id": "11111", "title": "Page One", "status": "current", "version": {"number": 1}}
+		],
+		"_links": {"next": "/wiki/api/v2/spaces/123456/pages?cursor=abc"}
+	}`)
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		space:   "DEV",
+		limit:   25,
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunList_PageList_LongTitle(t *testing.T) {
+	longTitle := strings.Repeat("A", 100)
+	server := mockListServer(t, "DEV", "123456", `{
+		"results": [
+			{"id": "11111", "title": "`+longTitle+`", "status": "current", "version": {"number": 1}}
+		]
+	}`)
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		space:   "DEV",
+		limit:   25,
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunList_PageList_StatusFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/pages") {
+			assert.Equal(t, "archived", r.URL.Query().Get("status"))
+		}
+		if r.URL.Query().Get("keys") != "" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"results": [{"id": "123456", "key": "DEV", "name": "Test", "type": "global"}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"results": []}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		space:   "DEV",
+		limit:   25,
+		status:  "archived",
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.NoError(t, err)
+}

--- a/internal/cmd/page/view_test.go
+++ b/internal/cmd/page/view_test.go
@@ -1,0 +1,160 @@
+package page
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rianjs/confluence-cli/api"
+)
+
+func TestRunView_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/pages/12345")
+		assert.Equal(t, "GET", r.Method)
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"id": "12345",
+			"title": "Test Page",
+			"version": {"number": 3},
+			"body": {"storage": {"value": "<p>Hello <strong>World</strong></p>"}},
+			"_links": {"webui": "/pages/12345"}
+		}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &viewOptions{
+		noColor: true,
+	}
+
+	err := runView("12345", opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunView_RawFormat(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"id": "12345",
+			"title": "Test Page",
+			"version": {"number": 1},
+			"body": {"storage": {"value": "<p>Raw HTML Content</p>"}},
+			"_links": {"webui": "/pages/12345"}
+		}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &viewOptions{
+		raw:     true,
+		noColor: true,
+	}
+
+	err := runView("12345", opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunView_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"id": "12345",
+			"title": "Test Page",
+			"version": {"number": 1},
+			"body": {"storage": {"value": "<p>Content</p>"}},
+			"_links": {"webui": "/pages/12345"}
+		}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &viewOptions{
+		output:  "json",
+		noColor: true,
+	}
+
+	err := runView("12345", opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunView_PageNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message": "Page not found"}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &viewOptions{
+		noColor: true,
+	}
+
+	err := runView("99999", opts, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get page")
+}
+
+func TestRunView_EmptyContent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"id": "12345",
+			"title": "Empty Page",
+			"version": {"number": 1},
+			"_links": {"webui": "/pages/12345"}
+		}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &viewOptions{
+		noColor: true,
+	}
+
+	err := runView("12345", opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunView_InvalidOutputFormat(t *testing.T) {
+	client := api.NewClient("http://unused", "test@example.com", "token")
+	opts := &viewOptions{
+		output:  "invalid",
+		noColor: true,
+	}
+
+	err := runView("12345", opts, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid output format")
+}
+
+func TestRunView_ShowMacros(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"id": "12345",
+			"title": "Page with Macros",
+			"version": {"number": 1},
+			"body": {"storage": {"value": "<ac:structured-macro ac:name=\"toc\"><ac:parameter ac:name=\"maxLevel\">2</ac:parameter></ac:structured-macro><p>Content</p>"}},
+			"_links": {"webui": "/pages/12345"}
+		}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &viewOptions{
+		showMacros: true,
+		noColor:    true,
+	}
+
+	err := runView("12345", opts, client)
+	require.NoError(t, err)
+}
+
+// Ensure strings is used
+var _ = strings.NewReader("")

--- a/internal/cmd/space/list_test.go
+++ b/internal/cmd/space/list_test.go
@@ -1,0 +1,238 @@
+package space
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rianjs/confluence-cli/api"
+)
+
+func TestRunList_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/spaces")
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"results": [
+				{
+					"id": "123456",
+					"key": "DEV",
+					"name": "Development",
+					"type": "global",
+					"description": {"plain": {"value": "Development team space"}}
+				},
+				{
+					"id": "789012",
+					"key": "DOCS",
+					"name": "Documentation",
+					"type": "global",
+					"description": {"plain": {"value": "Product documentation"}}
+				}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		limit:   25,
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunList_EmptyResults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"results": []}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		limit:   25,
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunList_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"results": [
+				{"id": "123456", "key": "DEV", "name": "Development", "type": "global"}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		limit:   25,
+		output:  "json",
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunList_InvalidOutputFormat(t *testing.T) {
+	opts := &listOptions{
+		limit:   25,
+		output:  "invalid",
+		noColor: true,
+	}
+
+	err := runList(opts, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid output format")
+}
+
+func TestRunList_NegativeLimit(t *testing.T) {
+	opts := &listOptions{
+		limit:   -1,
+		noColor: true,
+	}
+
+	err := runList(opts, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid limit")
+}
+
+func TestRunList_ZeroLimit(t *testing.T) {
+	opts := &listOptions{
+		limit:   0,
+		noColor: true,
+	}
+
+	// Zero limit should return empty without making API call
+	err := runList(opts, nil)
+	require.NoError(t, err)
+}
+
+func TestRunList_ZeroLimitJSON(t *testing.T) {
+	opts := &listOptions{
+		limit:   0,
+		output:  "json",
+		noColor: true,
+	}
+
+	// Zero limit should return empty JSON array without making API call
+	err := runList(opts, nil)
+	require.NoError(t, err)
+}
+
+func TestRunList_WithTypeFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "global", r.URL.Query().Get("type"))
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"results": [
+				{"id": "123456", "key": "DEV", "name": "Development", "type": "global"}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		limit:     25,
+		spaceType: "global",
+		noColor:   true,
+	}
+
+	err := runList(opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunList_WithLimitParameter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "50", r.URL.Query().Get("limit"))
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"results": []}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		limit:   50,
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunList_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"message": "Authentication required"}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		limit:   25,
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list spaces")
+}
+
+func TestRunList_HasMore(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"results": [
+				{"id": "123456", "key": "DEV", "name": "Development", "type": "global"}
+			],
+			"_links": {"next": "/wiki/api/v2/spaces?cursor=abc123"}
+		}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		limit:   25,
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.NoError(t, err)
+}
+
+func TestRunList_NullDescription(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"results": [
+				{"id": "123456", "key": "DEV", "name": "Development", "type": "global", "description": null}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	opts := &listOptions{
+		limit:   25,
+		noColor: true,
+	}
+
+	err := runList(opts, client)
+	require.NoError(t, err)
+}

--- a/internal/view/view_test.go
+++ b/internal/view/view_test.go
@@ -1,0 +1,273 @@
+package view
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		wantErr bool
+	}{
+		{"empty (default)", "", false},
+		{"table", "table", false},
+		{"json", "json", false},
+		{"plain", "plain", false},
+		{"invalid", "invalid", true},
+		{"xml", "xml", true},
+		{"TABLE uppercase", "TABLE", true}, // case-sensitive
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateFormat(tt.format)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid output format")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidFormats(t *testing.T) {
+	formats := ValidFormats()
+	assert.Contains(t, formats, "table")
+	assert.Contains(t, formats, "json")
+	assert.Contains(t, formats, "plain")
+	assert.Len(t, formats, 3)
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		maxLen int
+		want   string
+	}{
+		{"short string", "hello", 10, "hello"},
+		{"exact length", "hello", 5, "hello"},
+		{"truncate with ellipsis", "hello world", 8, "hello..."},
+		{"very short max", "hello", 3, "hel"},
+		{"empty string", "", 10, ""},
+		{"unicode bytes", "héllo wörld", 8, "héll..."}, // Truncate works on bytes, not runes
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Truncate(tt.input, tt.maxLen)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRenderer_RenderTable_Table(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewRenderer(FormatTable, true)
+	r.SetWriter(&buf)
+
+	headers := []string{"ID", "NAME", "STATUS"}
+	rows := [][]string{
+		{"1", "First", "active"},
+		{"2", "Second", "inactive"},
+	}
+
+	r.RenderTable(headers, rows)
+
+	output := buf.String()
+	assert.Contains(t, output, "ID")
+	assert.Contains(t, output, "NAME")
+	assert.Contains(t, output, "STATUS")
+	assert.Contains(t, output, "First")
+	assert.Contains(t, output, "Second")
+}
+
+func TestRenderer_RenderTable_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewRenderer(FormatJSON, true)
+	r.SetWriter(&buf)
+
+	headers := []string{"ID", "NAME"}
+	rows := [][]string{
+		{"1", "First"},
+		{"2", "Second"},
+	}
+
+	r.RenderTable(headers, rows)
+
+	// Verify it's valid JSON
+	var result []map[string]string
+	err := json.Unmarshal(buf.Bytes(), &result)
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, "1", result[0]["id"])
+	assert.Equal(t, "First", result[0]["name"])
+}
+
+func TestRenderer_RenderTable_Plain(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewRenderer(FormatPlain, true)
+	r.SetWriter(&buf)
+
+	headers := []string{"ID", "NAME"}
+	rows := [][]string{
+		{"1", "First"},
+		{"2", "Second"},
+	}
+
+	r.RenderTable(headers, rows)
+
+	// Plain format should use tabs and not include headers
+	output := buf.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	assert.Len(t, lines, 2)
+	assert.Contains(t, lines[0], "1\tFirst")
+	assert.Contains(t, lines[1], "2\tSecond")
+}
+
+func TestRenderer_RenderJSON(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewRenderer(FormatJSON, true)
+	r.SetWriter(&buf)
+
+	data := map[string]string{
+		"status": "ok",
+		"count":  "5",
+	}
+
+	err := r.RenderJSON(data)
+	require.NoError(t, err)
+
+	// Verify output is valid JSON
+	var result map[string]string
+	err = json.Unmarshal(buf.Bytes(), &result)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", result["status"])
+}
+
+func TestRenderer_RenderJSON_Array(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewRenderer(FormatJSON, true)
+	r.SetWriter(&buf)
+
+	err := r.RenderJSON([]interface{}{})
+	require.NoError(t, err)
+
+	output := strings.TrimSpace(buf.String())
+	assert.Equal(t, "[]", output)
+}
+
+func TestRenderer_RenderText(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewRenderer(FormatTable, true)
+	r.SetWriter(&buf)
+
+	r.RenderText("Hello, World!")
+
+	output := strings.TrimSpace(buf.String())
+	assert.Equal(t, "Hello, World!", output)
+}
+
+func TestRenderer_Success(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewRenderer(FormatTable, true)
+	r.SetWriter(&buf)
+
+	r.Success("Operation completed")
+
+	output := buf.String()
+	assert.Contains(t, output, "✓")
+	assert.Contains(t, output, "Operation completed")
+}
+
+func TestRenderer_Error(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewRenderer(FormatTable, true)
+	r.SetWriter(&buf)
+
+	r.Error("Something went wrong")
+
+	output := buf.String()
+	assert.Contains(t, output, "✗")
+	assert.Contains(t, output, "Something went wrong")
+}
+
+func TestRenderer_RenderKeyValue_Table(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewRenderer(FormatTable, true)
+	r.SetWriter(&buf)
+
+	r.RenderKeyValue("Status", "Active")
+
+	output := buf.String()
+	assert.Contains(t, output, "Status")
+	assert.Contains(t, output, "Active")
+}
+
+func TestRenderer_RenderKeyValue_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewRenderer(FormatJSON, true)
+	r.SetWriter(&buf)
+
+	r.RenderKeyValue("status", "active")
+
+	output := strings.TrimSpace(buf.String())
+	assert.Equal(t, `{"status": "active"}`, output)
+}
+
+func TestRenderer_EmptyTable(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewRenderer(FormatTable, true)
+	r.SetWriter(&buf)
+
+	r.RenderTable([]string{"ID", "NAME"}, [][]string{})
+
+	// Should still print headers
+	output := buf.String()
+	assert.Contains(t, output, "ID")
+	assert.Contains(t, output, "NAME")
+}
+
+func TestRenderer_EmptyTable_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewRenderer(FormatJSON, true)
+	r.SetWriter(&buf)
+
+	r.RenderTable([]string{"ID", "NAME"}, [][]string{})
+
+	// Should print null (empty array gives nil slice)
+	var result []map[string]string
+	err := json.Unmarshal(buf.Bytes(), &result)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestRenderer_RowWithFewerColumns(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewRenderer(FormatJSON, true)
+	r.SetWriter(&buf)
+
+	headers := []string{"ID", "NAME", "STATUS"}
+	rows := [][]string{
+		{"1", "First"}, // Missing STATUS
+	}
+
+	r.RenderTable(headers, rows)
+
+	var result []map[string]string
+	err := json.Unmarshal(buf.Bytes(), &result)
+	require.NoError(t, err)
+	assert.Equal(t, "1", result[0]["id"])
+	assert.Equal(t, "First", result[0]["name"])
+	// status should not be set
+	_, exists := result[0]["status"]
+	assert.False(t, exists)
+}


### PR DESCRIPTION
## Summary

- Add comprehensive test coverage for page, space, attachment commands and view rendering
- Refactor commands for testability with optional `*api.Client` dependency injection
- Add injectable `io.Reader` for stdin in delete confirmation flows

Cherry-picked and adapted test code from #6 for the current codebase.

## Test Files Added

| File | Coverage |
|------|----------|
| `internal/cmd/page/create_test.go` | 10 tests for page creation |
| `internal/cmd/page/delete_test.go` | 10 tests for delete confirmation flow |
| `internal/cmd/page/edit_test.go` | 9 tests for page editing |
| `internal/cmd/page/list_test.go` | 12 tests for page listing |
| `internal/cmd/page/view_test.go` | Tests for page view |
| `internal/cmd/space/list_test.go` | 12 tests for space listing |
| `internal/cmd/attachment/list_test.go` | Tests for attachment listing |
| `internal/cmd/attachment/upload_test.go` | Tests for attachment upload |
| `internal/view/view_test.go` | 17 tests for output rendering |

## Test plan

- [x] All existing tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [x] New tests are included and passing

Fixes #20
Supersedes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)