### PR TITLE
fix: preserve code blocks from Confluence UI pages in markdown output

### DIFF
--- a/integration-tests.md
+++ b/integration-tests.md
@@ -167,7 +167,7 @@ Pages created in Confluence's web UI use proprietary macros that may not round-t
 | Content Type | View | Edit | Result |
 |--------------|------|------|--------|
 | Tables | Flattened to text | **DESTROYED** | Use --no-markdown |
-| Code blocks (macro) | **STRIPPED** | **STRIPPED** | Use --no-markdown |
+| Code blocks (macro) | Pass | Pass | Preserved (fixed in #24) |
 | Info/warning panels | Stripped | Stripped | Use --no-markdown |
 | Expand macros | Stripped | Stripped | Use --no-markdown |
 | TOC macros | Stripped | Stripped | Use --no-markdown |


### PR DESCRIPTION
## Summary
- Confluence code blocks use `ac:structured-macro ac:name="code"` which were previously stripped
- Now extracts code content and language, converts to markdown code blocks
- Properly escapes HTML special characters (`<`, `>`, `&`) in code

## Example

**Before:** Code blocks from Confluence UI pages were silently stripped.

**After:** Code blocks are preserved with language syntax highlighting:

```
<ac:structured-macro ac:name="code">
  <ac:parameter ac:name="language">python</ac:parameter>
  <ac:plain-text-body><![CDATA[print("Hello")]]></ac:plain-text-body>
</ac:structured-macro>
```

Becomes:
````
```python
print("Hello")
```
````

## Test plan
- [x] Unit tests for code macro conversion (with/without language)
- [x] Tests for multiline code blocks
- [x] Tests for special characters in code
- [x] Verify non-code macros still stripped

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)