### PR TITLE
fix: enable GFM table extension in markdown converter

### DIFF
--- a/pkg/md/converter.go
+++ b/pkg/md/converter.go
@@ -5,6 +5,12 @@ import (
 	"bytes"
 
 	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+)
+
+// mdParser is a pre-configured goldmark instance with GFM table extension.
+var mdParser = goldmark.New(
+	goldmark.WithExtensions(extension.Table),
 )
 
 // ToConfluenceStorage converts markdown content to Confluence storage format (XHTML).
@@ -14,7 +20,7 @@ func ToConfluenceStorage(markdown []byte) (string, error) {
 	}
 
 	var buf bytes.Buffer
-	if err := goldmark.Convert(markdown, &buf); err != nil {
+	if err := mdParser.Convert(markdown, &buf); err != nil {
 		return "", err
 	}
 	return buf.String(), nil

--- a/pkg/md/converter_test.go
+++ b/pkg/md/converter_test.go
@@ -98,6 +98,16 @@ func TestToConfluenceStorage(t *testing.T) {
 			input:    "---",
 			expected: "<hr>\n",
 		},
+		{
+			name:     "simple table",
+			input:    "| A | B |\n|---|---|\n| 1 | 2 |",
+			expected: "<table>\n<thead>\n<tr>\n<th>A</th>\n<th>B</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>1</td>\n<td>2</td>\n</tr>\n</tbody>\n</table>\n",
+		},
+		{
+			name:     "table with multiple rows",
+			input:    "| Name | Age |\n|------|-----|\n| Alice | 30 |\n| Bob | 25 |",
+			expected: "<table>\n<thead>\n<tr>\n<th>Name</th>\n<th>Age</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>Alice</td>\n<td>30</td>\n</tr>\n<tr>\n<td>Bob</td>\n<td>25</td>\n</tr>\n</tbody>\n</table>\n",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Enable goldmark's GFM table extension in the markdown-to-HTML converter
- Markdown tables are now converted to proper `<table>` HTML elements when creating pages

## Before

```html
<p>| Col A | Col B |
|-------|-------|
| Val 1 | Val 2 |</p>
```

## After

```html
<table>
<thead>
<tr><th>Col A</th><th>Col B</th></tr>
</thead>
<tbody>
<tr><td>Val 1</td><td>Val 2</td></tr>
</tbody>
</table>
```

## Test plan

- [x] `make test` passes
- [x] New table test cases added to `converter_test.go`
- [x] Manual verification: created page with table, verified raw HTML contains `<table>` elements

Fixes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)