### PR TITLE
feat: add shell completion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,60 @@ cfl space list -o plain  # Tab-separated for piping to other tools
 
 ---
 
+## Shell Completion
+
+cfl supports tab completion for bash, zsh, fish, and PowerShell.
+
+### Bash
+
+```bash
+# Load in current session
+source <(cfl completion bash)
+
+# Install permanently (Linux)
+cfl completion bash | sudo tee /etc/bash_completion.d/cfl > /dev/null
+
+# Install permanently (macOS with Homebrew)
+cfl completion bash > $(brew --prefix)/etc/bash_completion.d/cfl
+```
+
+### Zsh
+
+```bash
+# Load in current session
+source <(cfl completion zsh)
+
+# Install permanently
+mkdir -p ~/.zsh/completions
+cfl completion zsh > ~/.zsh/completions/_cfl
+
+# Add to ~/.zshrc if not already present:
+# fpath=(~/.zsh/completions $fpath)
+# autoload -Uz compinit && compinit
+```
+
+### Fish
+
+```bash
+# Load in current session
+cfl completion fish | source
+
+# Install permanently
+cfl completion fish > ~/.config/fish/completions/cfl.fish
+```
+
+### PowerShell
+
+```powershell
+# Load in current session
+cfl completion powershell | Out-String | Invoke-Expression
+
+# Install permanently (add to $PROFILE)
+cfl completion powershell >> $PROFILE
+```
+
+---
+
 ## Development
 
 ### Prerequisites

--- a/internal/cmd/completion/bash.go
+++ b/internal/cmd/completion/bash.go
@@ -1,0 +1,39 @@
+package completion
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewCmdBash creates the bash completion command.
+func NewCmdBash() *cobra.Command {
+	return &cobra.Command{
+		Use:   "bash",
+		Short: "Generate bash completion script",
+		Long: `Generate bash completion script for cfl.
+
+To load completions in your current shell session:
+
+  source <(cfl completion bash)
+
+To load completions for every new session:
+
+  # Linux
+  cfl completion bash > /etc/bash_completion.d/cfl
+
+  # macOS (requires bash-completion)
+  cfl completion bash > $(brew --prefix)/etc/bash_completion.d/cfl`,
+		Example: `  # Load in current session
+  source <(cfl completion bash)
+
+  # Install permanently (Linux)
+  cfl completion bash | sudo tee /etc/bash_completion.d/cfl > /dev/null
+
+  # Install permanently (macOS with Homebrew)
+  cfl completion bash > $(brew --prefix)/etc/bash_completion.d/cfl`,
+		Args:                  cobra.NoArgs,
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Root().GenBashCompletion(cmd.OutOrStdout())
+		},
+	}
+}

--- a/internal/cmd/completion/completion.go
+++ b/internal/cmd/completion/completion.go
@@ -1,0 +1,25 @@
+// Package completion provides shell completion generation commands.
+package completion
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewCmdCompletion creates the completion command.
+func NewCmdCompletion() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "completion",
+		Short: "Generate shell completion scripts",
+		Long: `Generate shell completion scripts for cfl.
+
+These scripts enable tab-completion for commands, flags, and arguments.
+See each sub-command's help for installation instructions.`,
+	}
+
+	cmd.AddCommand(NewCmdBash())
+	cmd.AddCommand(NewCmdZsh())
+	cmd.AddCommand(NewCmdFish())
+	cmd.AddCommand(NewCmdPowerShell())
+
+	return cmd
+}

--- a/internal/cmd/completion/completion_test.go
+++ b/internal/cmd/completion/completion_test.go
@@ -1,0 +1,122 @@
+package completion
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createTestRootCmd creates a minimal root command for testing.
+func createTestRootCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "cfl",
+		Short: "Test CLI",
+	}
+}
+
+func TestNewCmdCompletion(t *testing.T) {
+	cmd := NewCmdCompletion()
+
+	assert.Equal(t, "completion", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotEmpty(t, cmd.Long)
+
+	// Should have 4 subcommands
+	assert.Len(t, cmd.Commands(), 4)
+}
+
+func TestBashCompletion(t *testing.T) {
+	root := createTestRootCmd()
+	root.AddCommand(NewCmdCompletion())
+
+	buf := new(bytes.Buffer)
+	root.SetOut(buf)
+	root.SetArgs([]string{"completion", "bash"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.NotEmpty(t, output)
+	// Bash completions should contain bash-specific markers
+	assert.Contains(t, output, "bash completion")
+}
+
+func TestZshCompletion(t *testing.T) {
+	root := createTestRootCmd()
+	root.AddCommand(NewCmdCompletion())
+
+	buf := new(bytes.Buffer)
+	root.SetOut(buf)
+	root.SetArgs([]string{"completion", "zsh"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.NotEmpty(t, output)
+	// Zsh completions should contain zsh-specific markers
+	assert.Contains(t, output, "compdef")
+}
+
+func TestFishCompletion(t *testing.T) {
+	root := createTestRootCmd()
+	root.AddCommand(NewCmdCompletion())
+
+	buf := new(bytes.Buffer)
+	root.SetOut(buf)
+	root.SetArgs([]string{"completion", "fish"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.NotEmpty(t, output)
+	// Fish completions should contain fish-specific markers
+	assert.Contains(t, output, "complete -c")
+}
+
+func TestPowerShellCompletion(t *testing.T) {
+	root := createTestRootCmd()
+	root.AddCommand(NewCmdCompletion())
+
+	buf := new(bytes.Buffer)
+	root.SetOut(buf)
+	root.SetArgs([]string{"completion", "powershell"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.NotEmpty(t, output)
+	// PowerShell completions should contain PowerShell-specific markers
+	assert.Contains(t, output, "Register-ArgumentCompleter")
+}
+
+func TestCompletionRejectsExtraArgs(t *testing.T) {
+	testCases := []struct {
+		name  string
+		shell string
+	}{
+		{"bash rejects args", "bash"},
+		{"zsh rejects args", "zsh"},
+		{"fish rejects args", "fish"},
+		{"powershell rejects args", "powershell"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := createTestRootCmd()
+			root.AddCommand(NewCmdCompletion())
+
+			root.SetArgs([]string{"completion", tc.shell, "unexpected-arg"})
+
+			err := root.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unknown command")
+		})
+	}
+}

--- a/internal/cmd/completion/fish.go
+++ b/internal/cmd/completion/fish.go
@@ -1,0 +1,32 @@
+package completion
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewCmdFish creates the fish completion command.
+func NewCmdFish() *cobra.Command {
+	return &cobra.Command{
+		Use:   "fish",
+		Short: "Generate fish completion script",
+		Long: `Generate fish completion script for cfl.
+
+To load completions in your current shell session:
+
+  cfl completion fish | source
+
+To load completions for every new session:
+
+  cfl completion fish > ~/.config/fish/completions/cfl.fish`,
+		Example: `  # Load in current session
+  cfl completion fish | source
+
+  # Install permanently
+  cfl completion fish > ~/.config/fish/completions/cfl.fish`,
+		Args:                  cobra.NoArgs,
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Root().GenFishCompletion(cmd.OutOrStdout(), true)
+		},
+	}
+}

--- a/internal/cmd/completion/powershell.go
+++ b/internal/cmd/completion/powershell.go
@@ -1,0 +1,31 @@
+package completion
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewCmdPowerShell creates the PowerShell completion command.
+func NewCmdPowerShell() *cobra.Command {
+	return &cobra.Command{
+		Use:   "powershell",
+		Short: "Generate PowerShell completion script",
+		Long: `Generate PowerShell completion script for cfl.
+
+To load completions in your current shell session:
+
+  cfl completion powershell | Out-String | Invoke-Expression
+
+To load completions for every new session, add the output to your
+PowerShell profile ($PROFILE).`,
+		Example: `  # Load in current session
+  cfl completion powershell | Out-String | Invoke-Expression
+
+  # Install permanently (add to $PROFILE)
+  cfl completion powershell >> $PROFILE`,
+		Args:                  cobra.NoArgs,
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Root().GenPowerShellCompletionWithDesc(cmd.OutOrStdout())
+		},
+	}
+}

--- a/internal/cmd/completion/zsh.go
+++ b/internal/cmd/completion/zsh.go
@@ -1,0 +1,44 @@
+package completion
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewCmdZsh creates the zsh completion command.
+func NewCmdZsh() *cobra.Command {
+	return &cobra.Command{
+		Use:   "zsh",
+		Short: "Generate zsh completion script",
+		Long: `Generate zsh completion script for cfl.
+
+To load completions in your current shell session:
+
+  source <(cfl completion zsh)
+
+To load completions for every new session, first ensure completion is enabled
+(add to ~/.zshrc if not already present):
+
+  autoload -Uz compinit && compinit
+
+Then add the completion script to your fpath:
+
+  cfl completion zsh > "${fpath[1]}/_cfl"
+
+You may need to start a new shell for completions to take effect.`,
+		Example: `  # Load in current session
+  source <(cfl completion zsh)
+
+  # Install permanently
+  mkdir -p ~/.zsh/completions
+  cfl completion zsh > ~/.zsh/completions/_cfl
+
+  # Then add to ~/.zshrc:
+  # fpath=(~/.zsh/completions $fpath)
+  # autoload -Uz compinit && compinit`,
+		Args:                  cobra.NoArgs,
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Root().GenZshCompletion(cmd.OutOrStdout())
+		},
+	}
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/rianjs/confluence-cli/internal/cmd/attachment"
+	"github.com/rianjs/confluence-cli/internal/cmd/completion"
 	initcmd "github.com/rianjs/confluence-cli/internal/cmd/init"
 	"github.com/rianjs/confluence-cli/internal/cmd/page"
 	"github.com/rianjs/confluence-cli/internal/cmd/search"
@@ -42,6 +43,7 @@ Get started by running: cfl init`,
 	cmd.AddCommand(space.NewCmdSpace())
 	cmd.AddCommand(attachment.NewCmdAttachment())
 	cmd.AddCommand(search.NewCmdSearch())
+	cmd.AddCommand(completion.NewCmdCompletion())
 
 	return cmd
 }

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v0.6.0 (2026-01-14)
+
+Add shell tab completion support for bash, zsh, fish, and PowerShell.
+
+### Features
+- Add `cfl completion` command with subcommands for bash, zsh, fish, and PowerShell ([#43](https://github.com/rianjs/confluence-cli/issues/43))
+
+---
+
 ## v0.5.0 (2026-01-13)
 
 Pages now use the modern cloud editor (ADF) format by default.


### PR DESCRIPTION
## Summary

- Add `cfl completion` command with subcommands for bash, zsh, fish, and PowerShell
- Each subcommand generates shell-specific completion scripts
- Help text includes installation instructions for each shell
- Add comprehensive tests for completion commands
- Update README with shell completion documentation

## Usage

```bash
# Bash - load in current session
source <(cfl completion bash)

# Zsh - load in current session
source <(cfl completion zsh)

# Fish - load in current session
cfl completion fish | source

# PowerShell - load in current session
cfl completion powershell | Out-String | Invoke-Expression
```

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (includes new completion tests)
- [x] `cfl completion --help` shows all subcommands
- [x] Each shell generates valid completion scripts
- [ ] Manual verification: `source <(cfl completion bash)` enables tab completion

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)