### PR TITLE
fix: validate empty content client-side before API call

### DIFF
--- a/integration-tests.md
+++ b/integration-tests.md
@@ -63,7 +63,8 @@ This document catalogs the manual integration test suite for `cfl`. These tests 
 | Missing space | `cfl page create -t "Test"` | Error: space required |
 | Duplicate title | Create same title twice | Error: "page already exists with same TITLE" |
 | Very long title (300+ chars) | Create with long title | Error: API rejects (400) |
-| Empty content | `echo "" \| cfl page create -s confluence -t "Empty"` | Page created (empty content allowed) |
+| Empty content | `echo "" \| cfl page create -s confluence -t "Empty"` | Error: "page content cannot be empty" |
+| Whitespace-only content | `echo "   " \| cfl page create -s confluence -t "Whitespace"` | Error: "page content cannot be empty" |
 | Create (cloud editor) | `echo "# Test" \| cfl page create -s confluence -t "Test"` | Page uses cloud editor (see verification below) |
 | Create (legacy editor) | `echo "# Test" \| cfl page create -s confluence -t "Test" --legacy` | Page uses legacy editor |
 | Create with code block (cloud) | Create page with fenced code block | Code block preserved as `codeBlock` in ADF |
@@ -84,6 +85,8 @@ This document catalogs the manual integration test suite for `cfl`. These tests 
 | Move with content update | `cfl page edit <id> --parent <parent-id> --file updated.md` | Page moved with new content |
 | Move to invalid parent | `cfl page edit <id> --parent 99999999999` | Error: 404 not found |
 | Move preserves history | Move page, then check version history | Previous versions still visible in UI |
+| Empty content from stdin | `echo "" \| cfl page edit <id>` | Error: "page content cannot be empty" |
+| Whitespace-only from stdin | `echo "   " \| cfl page edit <id>` | Error: "page content cannot be empty" |
 
 ### page copy
 

--- a/internal/cmd/page/create.go
+++ b/internal/cmd/page/create.go
@@ -145,6 +145,11 @@ func runCreate(opts *createOptions, client *api.Client) error {
 		return err
 	}
 
+	// Validate content is not empty
+	if strings.TrimSpace(content) == "" {
+		return fmt.Errorf("page content cannot be empty")
+	}
+
 	// Build request body based on legacy flag
 	var body *api.Body
 

--- a/internal/cmd/page/edit.go
+++ b/internal/cmd/page/edit.go
@@ -146,6 +146,11 @@ func runEdit(opts *editOptions, client *api.Client) error {
 			return err
 		}
 
+		// Validate content is not empty
+		if strings.TrimSpace(content) == "" {
+			return fmt.Errorf("page content cannot be empty")
+		}
+
 		// Convert content based on legacy flag
 		newContent, err = convertEditContent(content, isMarkdown, opts.legacy)
 		if err != nil {
@@ -159,6 +164,11 @@ func runEdit(opts *editOptions, client *api.Client) error {
 		content, isMarkdown, err := getEditContent(&editOptions{editor: true, markdown: opts.markdown}, existingPage)
 		if err != nil {
 			return err
+		}
+
+		// Validate content is not empty
+		if strings.TrimSpace(content) == "" {
+			return fmt.Errorf("page content cannot be empty")
 		}
 
 		newContent, err = convertEditContent(content, isMarkdown, opts.legacy)


### PR DESCRIPTION
## Summary

- Add client-side validation to reject empty or whitespace-only page content before making API calls
- Provides clear error message "page content cannot be empty" instead of confusing 500 error from Confluence
- Validation added to both `page create` and `page edit` commands

## Changes

- `internal/cmd/page/create.go`: Add validation after `getContent()` returns
- `internal/cmd/page/edit.go`: Add validation in two locations after `getEditContent()` returns
- `internal/cmd/page/create_test.go`: Add 4 unit tests for empty/whitespace content
- `internal/cmd/page/edit_test.go`: Add 5 unit tests for empty/whitespace content
- `integration-tests.md`: Update expected behavior for empty content tests

## Test plan

- [x] Unit tests pass: `make test`
- [x] Lint passes: `make lint`
- [ ] Manual verification:
  - `echo "" | cfl page create -s confluence -t "Empty"` → Error: "page content cannot be empty"
  - `echo "   " | cfl page create -s confluence -t "Whitespace"` → Error: "page content cannot be empty"
  - `echo "# Valid" | cfl page create -s confluence -t "Valid"` → Page created successfully

Fixes #59

🤖 Generated with [Claude Code](https://claude.ai/code)