### PR TITLE
fix: correct homebrew tap reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A command-line interface for Atlassian Confluence Cloud, inspired by [jira-cli](
 ### Homebrew (macOS)
 
 ```bash
-brew tap open-cli-collective/confluence-cli
+brew tap open-cli-collective/tap
 brew install --cask cfl
 ```
 


### PR DESCRIPTION
## Summary

Update homebrew installation instructions to use the shared `open-cli-collective/tap` repository instead of the non-existent `open-cli-collective/confluence-cli` tap.

## Changes

- Changed `brew tap open-cli-collective/confluence-cli` to `brew tap open-cli-collective/tap`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update