### PR TITLE
fix: allow --parent flag to move page without content

### DIFF
--- a/integration-tests.md
+++ b/integration-tests.md
@@ -85,6 +85,8 @@ This document catalogs the manual integration test suite for `cfl`. These tests 
 | Move with content update | `cfl page edit <id> --parent <parent-id> --file updated.md` | Page moved with new content |
 | Move to invalid parent | `cfl page edit <id> --parent 99999999999` | Error: 404 not found |
 | Move preserves history | Move page, then check version history | Previous versions still visible in UI |
+| Move page (no content change) | `cfl page edit <id> --parent <parent-id>` | Page moved without opening editor, content unchanged |
+| Move and rename (no content change) | `cfl page edit <id> --parent <parent-id> --title "New Title"` | Page moved and renamed without editor |
 | Empty content from stdin | `echo "" \| cfl page edit <id>` | Error: "page content cannot be empty" |
 | Whitespace-only from stdin | `echo "   " \| cfl page edit <id>` | Error: "page content cannot be empty" |
 
@@ -382,7 +384,9 @@ Before GA release, run through this checklist:
 - [ ] Edit page from file
 - [ ] Edit page with --legacy flag
 - [ ] Move page to new parent (`--parent` flag)
+- [ ] Move page (no content change, no editor opened)
 - [ ] Move and rename page together
+- [ ] Move and rename (no content change, no editor opened)
 - [ ] Verify page history preserved after move
 - [ ] Copy page (same space)
 - [ ] Copy page (different space)

--- a/internal/cmd/page/edit.go
+++ b/internal/cmd/page/edit.go
@@ -159,8 +159,8 @@ func runEdit(opts *editOptions, client *api.Client) error {
 		hasNewContent = true
 	}
 
-	// If no new content and no new title, open editor by default
-	if !hasNewContent && opts.title == "" {
+	// If no new content and no new title and no parent move, open editor by default
+	if !hasNewContent && opts.title == "" && opts.parent == "" {
 		content, isMarkdown, err := getEditContent(&editOptions{editor: true, markdown: opts.markdown}, existingPage)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary
- Fixes the condition at `edit.go:163` to also check `opts.parent == ""`
- Previously, `cfl page edit <id> --parent <new-parent-id>` would open an interactive editor
- Now move-only and move+title operations work without requiring content

## Changes
| File | Change |
|------|--------|
| `internal/cmd/page/edit.go` | Add `&& opts.parent == ""` to editor-opening condition |
| `internal/cmd/page/edit_test.go` | Add 3 unit tests for move-only scenarios |
| `integration-tests.md` | Add 2 integration test cases + checklist items |

## Test plan
- [x] `TestRunEdit_MoveOnly_NoEditorOpened` - Move page without content change
- [x] `TestRunEdit_MoveWithTitleOnly_NoEditorOpened` - Move + title update without content
- [x] `TestRunEdit_MoveOnly_BodyPreserved` - Verify body is preserved during move-only
- [ ] Manual test: `cfl page edit <id> --parent <parent-id>` moves without opening editor
- [ ] Manual test: `cfl page edit <id> --parent <parent-id> --title "New"` moves and renames without editor

Fixes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)