### PR TITLE
feat: smarter release triggers and automated Chocolatey publishing

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+    # Gate 1: Only trigger when Go code actually changes
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
 
 permissions:
   contents: write
@@ -11,8 +16,12 @@ permissions:
 jobs:
   create-release:
     runs-on: ubuntu-latest
-    # Skip if commit is from the release workflow (avoid loops)
-    if: "!startsWith(github.event.head_commit.message, 'chore:') && !startsWith(github.event.head_commit.message, 'chore(')"
+    # Gate 2: Only release for feat: and fix: commits (actual functionality changes)
+    if: >-
+      startsWith(github.event.head_commit.message, 'feat:') ||
+      startsWith(github.event.head_commit.message, 'feat(') ||
+      startsWith(github.event.head_commit.message, 'fix:') ||
+      startsWith(github.event.head_commit.message, 'fix(')
     steps:
       # TAP_GITHUB_TOKEN (a PAT) is required here instead of the default GITHUB_TOKEN
       # because tag pushes made with GITHUB_TOKEN do not trigger other workflows.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,3 +28,30 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+
+  chocolatey:
+    needs: goreleaser
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update version in nuspec
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart('v')
+          $nuspec = 'packaging/chocolatey/confluence-cli.nuspec'
+          (Get-Content $nuspec) -replace '<version>0.0.0</version>', "<version>$version</version>" | Set-Content $nuspec
+          Write-Host "Updated nuspec to version $version"
+
+      - name: Pack Chocolatey package
+        shell: pwsh
+        run: |
+          cd packaging/chocolatey
+          choco pack
+          Get-ChildItem *.nupkg
+
+      - name: Push to Chocolatey
+        shell: pwsh
+        run: |
+          cd packaging/chocolatey
+          choco push (Get-ChildItem *.nupkg).Name --source https://push.chocolatey.org/ --key ${{ secrets.CHOCOLATEY_API_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,14 +183,20 @@ Use these prefixes for commit messages:
 
 ## Release Workflow
 
-Releases are automated via release-please. When PRs merge to main with conventional commits:
-- `feat:` → minor version bump
-- `fix:` → patch version bump
-- `BREAKING CHANGE:` or `feat!:` → major version bump
+Releases are automated with a dual-gate system to avoid unnecessary releases:
+
+**Gate 1 - Path filter:** Only triggers when Go code changes (`**.go`, `go.mod`, `go.sum`)
+**Gate 2 - Commit prefix:** Only `feat:` and `fix:` commits create releases
+
+This means:
+- ✅ `feat: add command` + Go files changed → release
+- ✅ `fix: handle edge case` + Go files changed → release
+- ❌ `docs:`, `ci:`, `test:`, `refactor:` → no release
+- ❌ Changes only to docs, packaging, workflows → no release
 
 **Before merging a PR:** Run `/release-notes` to generate release notes and update the PR description.
 
-**After merging:** release-please creates a Release PR. Merging that PR triggers the full release (GitHub Release + Homebrew tap update).
+**After merging a release-triggering PR:** The workflow creates a tag, which triggers GoReleaser to build binaries and publish to Homebrew and Chocolatey.
 
 ## Packaging
 
@@ -212,6 +218,6 @@ packaging/
     └── README.md            # Points to GoReleaser config
 ```
 
-- **Homebrew**: Managed by GoReleaser, published to [open-cli-collective/homebrew-tap](https://github.com/open-cli-collective/homebrew-tap)
-- **Chocolatey**: Manual publish process documented in `packaging/chocolatey/README.md`
-- **Winget**: PR submission to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs), documented in `packaging/winget/README.md`
+- **Homebrew**: Automated via GoReleaser, published to [open-cli-collective/homebrew-tap](https://github.com/open-cli-collective/homebrew-tap)
+- **Chocolatey**: Automated via release workflow, requires `CHOCOLATEY_API_KEY` secret
+- **Winget**: Manual PR submission to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs), documented in `packaging/winget/README.md`

--- a/README.md
+++ b/README.md
@@ -16,11 +16,23 @@ A command-line interface for Atlassian Confluence Cloud, inspired by [jira-cli](
 
 ## Installation
 
-### Homebrew (macOS)
+### Homebrew (macOS/Linux)
 
 ```bash
 brew tap open-cli-collective/tap
-brew install --cask cfl
+brew install cfl
+```
+
+### Chocolatey (Windows)
+
+```powershell
+choco install confluence-cli
+```
+
+### Winget (Windows)
+
+```powershell
+winget install OpenCLICollective.cfl
 ```
 
 ### Go Install
@@ -32,6 +44,8 @@ go install github.com/open-cli-collective/confluence-cli/cmd/cfl@latest
 ### Binary Download
 
 Download the latest release from the [Releases page](https://github.com/open-cli-collective/confluence-cli/releases).
+
+Available for Windows (x64, ARM64), macOS (Intel, Apple Silicon), and Linux (x64, ARM64).
 
 ## Quick Start
 

--- a/packaging/chocolatey/README.md
+++ b/packaging/chocolatey/README.md
@@ -2,6 +2,16 @@
 
 This directory contains the Chocolatey package definition for distributing confluence-cli on Windows.
 
+## Automated Publishing
+
+Publishing to Chocolatey is automated via GitHub Actions. When a new release tag is pushed, the release workflow:
+
+1. Builds binaries with GoReleaser
+2. Packs the Chocolatey package with the release version
+3. Pushes to the Chocolatey Community Repository
+
+**Required secret:** `CHOCOLATEY_API_KEY` must be configured in repository settings.
+
 ## Package Structure
 
 ```


### PR DESCRIPTION
## Summary

- Add dual-gate release triggers to avoid unnecessary releases
- Automate Chocolatey package publishing as part of the release workflow
- Update README with Windows installation options (Chocolatey, Winget)

## Changes

### Smarter Release Triggers (`auto-release.yml`)

**Gate 1 - Path filter:** Only triggers when Go code changes (`**.go`, `go.mod`, `go.sum`)

**Gate 2 - Commit prefix:** Only `feat:` and `fix:` commits create releases

This means:
- ✅ `feat: add command` + Go files changed → release
- ✅ `fix: handle edge case` + Go files changed → release
- ❌ `docs:`, `ci:`, `test:`, `refactor:` → no release
- ❌ Changes only to docs, packaging, workflows → no release

### Automated Chocolatey Publishing (`release.yml`)

Adds a `chocolatey` job that runs after GoReleaser:
1. Updates nuspec version from placeholder to release version
2. Packs the Chocolatey package
3. Pushes to the Chocolatey Community Repository

### README Updates

Added installation instructions for:
- Chocolatey (Windows)
- Winget (Windows)
- Platform availability note

Also fixed Homebrew install command (removed `--cask` flag).

## Required Setup

After merging, add the `CHOCOLATEY_API_KEY` secret to the repository:
1. Create account at https://community.chocolatey.org
2. Get API key from https://community.chocolatey.org/account
3. Add as repository secret named `CHOCOLATEY_API_KEY`

Fixes #80