### PR TITLE
feat: add manual Chocolatey publish workflow

### DIFF
--- a/.github/workflows/chocolatey-publish.yml
+++ b/.github/workflows/chocolatey-publish.yml
@@ -1,0 +1,47 @@
+name: Publish to Chocolatey
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 0.9.8)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate release exists
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $release = gh release view "v${{ inputs.version }}" --json tagName 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Release v${{ inputs.version }} not found"
+            exit 1
+          }
+          Write-Host "Found release v${{ inputs.version }}"
+
+      - name: Update version in nuspec
+        shell: pwsh
+        run: |
+          $nuspec = 'packaging/chocolatey/confluence-cli.nuspec'
+          (Get-Content $nuspec) -replace '<version>0.0.0</version>', "<version>${{ inputs.version }}</version>" | Set-Content $nuspec
+          Write-Host "Updated nuspec to version ${{ inputs.version }}"
+
+      - name: Pack Chocolatey package
+        shell: pwsh
+        run: |
+          cd packaging/chocolatey
+          choco pack
+          Get-ChildItem *.nupkg
+
+      - name: Push to Chocolatey
+        shell: pwsh
+        run: |
+          cd packaging/chocolatey
+          choco push (Get-ChildItem *.nupkg).Name --source https://push.chocolatey.org/ --key ${{ secrets.CHOCOLATEY_API_KEY }}


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` workflow for manually publishing releases to Chocolatey.

## Use Cases

1. **Initial submission** - Publish v0.9.8 to start the moderation process
2. **Retry failed publishes** - If automated publish fails
3. **Backfill** - Publish older versions if needed

## Usage

1. Go to Actions → "Publish to Chocolatey"
2. Click "Run workflow"
3. Enter version (e.g., `0.9.8`)
4. Click "Run workflow"

The workflow validates the release exists before attempting to publish.

Fixes #82