### PR TITLE
feat: skip Go builds in CI when no Go code changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,24 @@ on:
     branches: [main]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            go:
+              - '**.go'
+              - 'go.mod'
+              - 'go.sum'
+
   build-and-test:
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,6 +49,8 @@ jobs:
           fail_ci_if_error: false
 
   lint:
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,9 +181,11 @@ Use these prefixes for commit messages:
 - `refactor:` - Code changes that don't fix bugs or add features
 - `BREAKING CHANGE:` or `feat!:` - Breaking changes (major version bump)
 
-## Release Workflow
+## CI & Release Workflow
 
-Releases are automated with a dual-gate system to avoid unnecessary releases:
+**CI** skips Go build/test/lint jobs when only non-Go files change (docs, packaging, workflows). Jobs show as "Skipped" rather than not running, so branch protection still works.
+
+**Releases** are automated with a dual-gate system to avoid unnecessary releases:
 
 **Gate 1 - Path filter:** Only triggers when Go code changes (`**.go`, `go.mod`, `go.sum`)
 **Gate 2 - Commit prefix:** Only `feat:` and `fix:` commits create releases


### PR DESCRIPTION
## Summary

Skip Go build, test, and lint jobs when PRs only change non-Go files (docs, packaging, workflows, assets).

Related to #80 (smarter release triggers) - applies the same philosophy to CI.

## How It Works

1. New `changes` job runs first using `dorny/paths-filter`
2. Detects if any Go files changed (`**.go`, `go.mod`, `go.sum`)
3. `build-and-test` and `lint` jobs check the output
4. If no Go files changed → jobs show as "Skipped"

## Why Not Workflow-Level `paths:` Filter?

Branch protection requires status checks to be reported. If the workflow doesn't run at all, status is "Missing" and PR can't merge. This approach ensures jobs always report status.

## Behavior

| PR Changes | build-and-test | lint |
|------------|----------------|------|
| Go code | Runs | Runs |
| Docs only | Skipped | Skipped |
| Workflows only | Skipped | Skipped |
| Packaging only | Skipped | Skipped |

Fixes #84