### PR TITLE
feat: automate Winget package submission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,25 @@ jobs:
         run: |
           cd packaging/chocolatey
           choco push (Get-ChildItem *.nupkg).Name --source https://push.chocolatey.org/ --key ${{ secrets.CHOCOLATEY_API_KEY }}
+
+  winget:
+    needs: goreleaser
+    runs-on: windows-latest
+    steps:
+      - name: Install wingetcreate
+        shell: pwsh
+        run: |
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+
+      - name: Submit to Winget
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart('v')
+          $x64 = "https://github.com/open-cli-collective/confluence-cli/releases/download/${{ github.ref_name }}/cfl_${version}_windows_amd64.zip"
+          $arm64 = "https://github.com/open-cli-collective/confluence-cli/releases/download/${{ github.ref_name }}/cfl_${version}_windows_arm64.zip"
+
+          Write-Host "Submitting version $version to Winget"
+          Write-Host "x64 URL: $x64"
+          Write-Host "arm64 URL: $arm64"
+
+          ./wingetcreate.exe update OpenCLICollective.cfl --version $version --urls $x64 $arm64 --submit --token ${{ secrets.WINGET_GITHUB_TOKEN }}

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,0 +1,43 @@
+name: Publish to Winget
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 0.9.9)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - name: Install wingetcreate
+        shell: pwsh
+        run: |
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+
+      - name: Validate release exists
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $release = gh release view "v${{ inputs.version }}" --repo open-cli-collective/confluence-cli --json tagName 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Release v${{ inputs.version }} not found"
+            exit 1
+          }
+          Write-Host "Found release v${{ inputs.version }}"
+
+      - name: Submit to Winget
+        shell: pwsh
+        run: |
+          $version = "${{ inputs.version }}"
+          $x64 = "https://github.com/open-cli-collective/confluence-cli/releases/download/v$version/cfl_${version}_windows_amd64.zip"
+          $arm64 = "https://github.com/open-cli-collective/confluence-cli/releases/download/v$version/cfl_${version}_windows_arm64.zip"
+
+          Write-Host "Submitting version $version to Winget"
+          Write-Host "x64 URL: $x64"
+          Write-Host "arm64 URL: $arm64"
+
+          ./wingetcreate.exe update OpenCLICollective.cfl --version $version --urls $x64 $arm64 --submit --token ${{ secrets.WINGET_GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,4 +222,4 @@ packaging/
 
 - **Homebrew**: Automated via GoReleaser, published to [open-cli-collective/homebrew-tap](https://github.com/open-cli-collective/homebrew-tap)
 - **Chocolatey**: Automated via release workflow, requires `CHOCOLATEY_API_KEY` secret
-- **Winget**: Manual PR submission to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs), documented in `packaging/winget/README.md`
+- **Winget**: Automated via release workflow, requires `WINGET_GITHUB_TOKEN` secret (PAT with `public_repo` scope)

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -2,6 +2,14 @@
 
 This directory contains the Winget manifest templates for distributing confluence-cli on Windows via `winget install OpenCLICollective.cfl`.
 
+## Automated Publishing
+
+Publishing to Winget is automated via GitHub Actions. When a new release tag is pushed, the release workflow uses `wingetcreate` to submit a PR to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs).
+
+**Required secret:** `WINGET_GITHUB_TOKEN` - A GitHub PAT with `public_repo` scope, needed to create PRs on microsoft/winget-pkgs.
+
+**Note:** Unlike Chocolatey (direct publish), Winget submissions are PRs that go through Microsoft's automated validation before merging.
+
 ## Manifest Structure
 
 ```


### PR DESCRIPTION
## Summary

Automates Winget package submission using `wingetcreate` to create PRs to microsoft/winget-pkgs.

## Changes

### New: Manual Workflow (`.github/workflows/winget-publish.yml`)

For initial submission and retries:
1. Go to Actions → "Publish to Winget"
2. Enter version (e.g., `0.9.9`)
3. Workflow creates PR to microsoft/winget-pkgs

### Updated: Release Workflow (`.github/workflows/release.yml`)

Adds `winget` job that runs after GoReleaser to automatically submit new releases.

### Documentation Updates

- `CLAUDE.md` - Updated Winget entry in packaging section
- `packaging/winget/README.md` - Added automation section

## Required Setup

1. Create GitHub PAT with `public_repo` scope at https://github.com/settings/tokens
2. Add as org/repo secret named `WINGET_GITHUB_TOKEN`

## How It Works

Unlike Chocolatey (direct publish), Winget uses `wingetcreate --submit` which:
1. Downloads the release artifacts
2. Computes SHA256 checksums
3. Generates manifest files
4. Creates a PR to microsoft/winget-pkgs
5. Microsoft's automation validates and merges

Closes #77