### PR TITLE
fix: handle initial Winget submission when manifest doesn't exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,20 +60,82 @@ jobs:
     needs: goreleaser
     runs-on: windows-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Install wingetcreate
         shell: pwsh
         run: |
           Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
 
-      - name: Submit to Winget
+      - name: Check if manifest exists in winget-pkgs
+        id: check-manifest
+        shell: pwsh
+        run: |
+          $response = Invoke-WebRequest -Uri "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/o/OpenCLICollective/cfl" -Method Head -SkipHttpErrorCheck
+          if ($response.StatusCode -eq 200) {
+            Write-Host "Manifest exists - will use wingetcreate update"
+            echo "exists=true" >> $env:GITHUB_OUTPUT
+          } else {
+            Write-Host "Manifest does not exist - will use wingetcreate new"
+            echo "exists=false" >> $env:GITHUB_OUTPUT
+          }
+
+      - name: Get checksums from release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart('v')
+          gh release download "${{ github.ref_name }}" --repo open-cli-collective/confluence-cli --pattern "checksums.txt" --dir .
+
+          $checksums = Get-Content checksums.txt
+          $x64Hash = ($checksums | Select-String "windows_amd64.zip").Line.Split()[0]
+          $arm64Hash = ($checksums | Select-String "windows_arm64.zip").Line.Split()[0]
+
+          Write-Host "x64 SHA256: $x64Hash"
+          Write-Host "arm64 SHA256: $arm64Hash"
+
+          echo "X64_HASH=$x64Hash" >> $env:GITHUB_ENV
+          echo "ARM64_HASH=$arm64Hash" >> $env:GITHUB_ENV
+
+      - name: Update manifest (existing package)
+        if: steps.check-manifest.outputs.exists == 'true'
         shell: pwsh
         run: |
           $version = "${{ github.ref_name }}".TrimStart('v')
           $x64 = "https://github.com/open-cli-collective/confluence-cli/releases/download/${{ github.ref_name }}/cfl_${version}_windows_amd64.zip"
           $arm64 = "https://github.com/open-cli-collective/confluence-cli/releases/download/${{ github.ref_name }}/cfl_${version}_windows_arm64.zip"
 
-          Write-Host "Submitting version $version to Winget"
-          Write-Host "x64 URL: $x64"
-          Write-Host "arm64 URL: $arm64"
-
+          Write-Host "Updating existing manifest to version $version"
           ./wingetcreate.exe update OpenCLICollective.cfl --version $version --urls $x64 $arm64 --submit --token ${{ secrets.WINGET_GITHUB_TOKEN }}
+
+      - name: Create manifest (new package)
+        if: steps.check-manifest.outputs.exists == 'false'
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart('v')
+          $manifestDir = "manifests"
+          New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+
+          # Update version manifest
+          $versionManifest = Get-Content "packaging/winget/OpenCLICollective.cfl.yaml" -Raw
+          $versionManifest = $versionManifest -replace "0\.0\.0", $version
+          Set-Content "$manifestDir/OpenCLICollective.cfl.yaml" $versionManifest
+
+          # Update locale manifest
+          $localeManifest = Get-Content "packaging/winget/OpenCLICollective.cfl.locale.en-US.yaml" -Raw
+          $localeManifest = $localeManifest -replace "0\.0\.0", $version
+          Set-Content "$manifestDir/OpenCLICollective.cfl.locale.en-US.yaml" $localeManifest
+
+          # Update installer manifest with version and real checksums
+          $installerManifest = Get-Content "packaging/winget/OpenCLICollective.cfl.installer.yaml" -Raw
+          $installerManifest = $installerManifest -replace "0\.0\.0", $version
+          $installerManifest = $installerManifest -replace "0{64}", $env:X64_HASH, 1
+          $installerManifest = $installerManifest -replace "0{64}", $env:ARM64_HASH, 1
+          Set-Content "$manifestDir/OpenCLICollective.cfl.installer.yaml" $installerManifest
+
+          Write-Host "Generated manifests:"
+          Get-ChildItem $manifestDir | ForEach-Object { Write-Host "  $_" }
+
+          Write-Host "`nSubmitting new package to Winget..."
+          ./wingetcreate.exe submit --token ${{ secrets.WINGET_GITHUB_TOKEN }} $manifestDir

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -12,6 +12,8 @@ jobs:
   publish:
     runs-on: windows-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Install wingetcreate
         shell: pwsh
         run: |
@@ -29,15 +31,75 @@ jobs:
           }
           Write-Host "Found release v${{ inputs.version }}"
 
-      - name: Submit to Winget
+      - name: Check if manifest exists in winget-pkgs
+        id: check-manifest
+        shell: pwsh
+        run: |
+          $response = Invoke-WebRequest -Uri "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/o/OpenCLICollective/cfl" -Method Head -SkipHttpErrorCheck
+          if ($response.StatusCode -eq 200) {
+            Write-Host "Manifest exists - will use wingetcreate update"
+            echo "exists=true" >> $env:GITHUB_OUTPUT
+          } else {
+            Write-Host "Manifest does not exist - will use wingetcreate new"
+            echo "exists=false" >> $env:GITHUB_OUTPUT
+          }
+
+      - name: Get checksums from release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $version = "${{ inputs.version }}"
+          gh release download "v$version" --repo open-cli-collective/confluence-cli --pattern "checksums.txt" --dir .
+
+          $checksums = Get-Content checksums.txt
+          $x64Hash = ($checksums | Select-String "windows_amd64.zip").Line.Split()[0]
+          $arm64Hash = ($checksums | Select-String "windows_arm64.zip").Line.Split()[0]
+
+          Write-Host "x64 SHA256: $x64Hash"
+          Write-Host "arm64 SHA256: $arm64Hash"
+
+          echo "X64_HASH=$x64Hash" >> $env:GITHUB_ENV
+          echo "ARM64_HASH=$arm64Hash" >> $env:GITHUB_ENV
+
+      - name: Update manifest (existing package)
+        if: steps.check-manifest.outputs.exists == 'true'
         shell: pwsh
         run: |
           $version = "${{ inputs.version }}"
           $x64 = "https://github.com/open-cli-collective/confluence-cli/releases/download/v$version/cfl_${version}_windows_amd64.zip"
           $arm64 = "https://github.com/open-cli-collective/confluence-cli/releases/download/v$version/cfl_${version}_windows_arm64.zip"
 
-          Write-Host "Submitting version $version to Winget"
-          Write-Host "x64 URL: $x64"
-          Write-Host "arm64 URL: $arm64"
-
+          Write-Host "Updating existing manifest to version $version"
           ./wingetcreate.exe update OpenCLICollective.cfl --version $version --urls $x64 $arm64 --submit --token ${{ secrets.WINGET_GITHUB_TOKEN }}
+
+      - name: Create manifest (new package)
+        if: steps.check-manifest.outputs.exists == 'false'
+        shell: pwsh
+        run: |
+          $version = "${{ inputs.version }}"
+          $manifestDir = "manifests"
+          New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+
+          # Update version manifest
+          $versionManifest = Get-Content "packaging/winget/OpenCLICollective.cfl.yaml" -Raw
+          $versionManifest = $versionManifest -replace "0\.0\.0", $version
+          Set-Content "$manifestDir/OpenCLICollective.cfl.yaml" $versionManifest
+
+          # Update locale manifest
+          $localeManifest = Get-Content "packaging/winget/OpenCLICollective.cfl.locale.en-US.yaml" -Raw
+          $localeManifest = $localeManifest -replace "0\.0\.0", $version
+          Set-Content "$manifestDir/OpenCLICollective.cfl.locale.en-US.yaml" $localeManifest
+
+          # Update installer manifest with version and real checksums
+          $installerManifest = Get-Content "packaging/winget/OpenCLICollective.cfl.installer.yaml" -Raw
+          $installerManifest = $installerManifest -replace "0\.0\.0", $version
+          $installerManifest = $installerManifest -replace "0{64}", $env:X64_HASH, 1
+          $installerManifest = $installerManifest -replace "0{64}", $env:ARM64_HASH, 1
+          Set-Content "$manifestDir/OpenCLICollective.cfl.installer.yaml" $installerManifest
+
+          Write-Host "Generated manifests:"
+          Get-ChildItem $manifestDir | ForEach-Object { Write-Host "  $_" }
+
+          Write-Host "`nSubmitting new package to Winget..."
+          ./wingetcreate.exe submit --token ${{ secrets.WINGET_GITHUB_TOKEN }} $manifestDir


### PR DESCRIPTION
## Problem

The Winget workflow failed because `wingetcreate update` requires an existing manifest in microsoft/winget-pkgs:

```
ERROR: repos/microsoft/winget-pkgs/contents/manifests/o/OpenCLICollective/cfl was not found.
```

For the **initial submission**, there's no existing manifest to update.

## Solution

Both workflows now:
1. Check if manifest exists in winget-pkgs via GitHub API
2. If exists → use `wingetcreate update` (fast, just needs URLs)
3. If not exists → use our template manifests from `packaging/winget/`, substitute version and real checksums, then use `wingetcreate submit`

## Changes

- `.github/workflows/winget-publish.yml` - Add manifest existence check and branching logic
- `.github/workflows/release.yml` - Same changes to winget job

Follow-up to #77