### PR TITLE
fix: use .NET regex for single replacement in PowerShell

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,8 +130,10 @@ jobs:
           # Update installer manifest with version and real checksums
           $installerManifest = Get-Content "packaging/winget/OpenCLICollective.cfl.installer.yaml" -Raw
           $installerManifest = $installerManifest -replace "0\.0\.0", $version
-          $installerManifest = $installerManifest -replace "0{64}", $env:X64_HASH, 1
-          $installerManifest = $installerManifest -replace "0{64}", $env:ARM64_HASH, 1
+          # Replace checksums one at a time using .NET regex (PowerShell -replace doesn't support count)
+          $regex = [regex]"0{64}"
+          $installerManifest = $regex.Replace($installerManifest, $env:X64_HASH, 1)
+          $installerManifest = $regex.Replace($installerManifest, $env:ARM64_HASH, 1)
           Set-Content "$manifestDir/OpenCLICollective.cfl.installer.yaml" $installerManifest
 
           Write-Host "Generated manifests:"

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -94,8 +94,10 @@ jobs:
           # Update installer manifest with version and real checksums
           $installerManifest = Get-Content "packaging/winget/OpenCLICollective.cfl.installer.yaml" -Raw
           $installerManifest = $installerManifest -replace "0\.0\.0", $version
-          $installerManifest = $installerManifest -replace "0{64}", $env:X64_HASH, 1
-          $installerManifest = $installerManifest -replace "0{64}", $env:ARM64_HASH, 1
+          # Replace checksums one at a time using .NET regex (PowerShell -replace doesn't support count)
+          $regex = [regex]"0{64}"
+          $installerManifest = $regex.Replace($installerManifest, $env:X64_HASH, 1)
+          $installerManifest = $regex.Replace($installerManifest, $env:ARM64_HASH, 1)
           Set-Content "$manifestDir/OpenCLICollective.cfl.installer.yaml" $installerManifest
 
           Write-Host "Generated manifests:"


### PR DESCRIPTION
## Problem

PowerShell's `-replace` operator doesn't support a count argument:

```
The -replace operator allows only two elements to follow it, not 3.
```

## Solution

Use `[regex]::Replace()` which supports a count parameter to replace checksums one at a time (x64 first, then arm64).

```powershell
$regex = [regex]"0{64}"
$installerManifest = $regex.Replace($installerManifest, $env:X64_HASH, 1)
$installerManifest = $regex.Replace($installerManifest, $env:ARM64_HASH, 1)
```

Follow-up to #77