### PR TITLE
feat: improve Winget manifest validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,5 +139,13 @@ jobs:
           Write-Host "Generated manifests:"
           Get-ChildItem $manifestDir | ForEach-Object { Write-Host "  $_" }
 
+          Write-Host "`nValidating manifests..."
+          winget validate --manifest $manifestDir
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Manifest validation failed"
+            exit 1
+          }
+          Write-Host "Validation passed!"
+
           Write-Host "`nSubmitting new package to Winget..."
           ./wingetcreate.exe submit --token ${{ secrets.WINGET_GITHUB_TOKEN }} $manifestDir

--- a/.github/workflows/test-winget.yml
+++ b/.github/workflows/test-winget.yml
@@ -20,54 +20,38 @@ jobs:
       - name: Validate manifest schema
         shell: pwsh
         run: |
-          # Create temp manifests with valid HTTPS URLs for schema validation
-          # (winget validate requires HTTPS URLs)
           $testDir = "winget-validate-test"
+          $testVersion = "0.0.1"
+          $testHash1 = "0000000000000000000000000000000000000000000000000000000000000001"
+          $testHash2 = "0000000000000000000000000000000000000000000000000000000000000002"
+
           New-Item -ItemType Directory -Path $testDir -Force | Out-Null
 
-          Set-Content "$testDir/OpenCLICollective.cfl.yaml" -Encoding UTF8 @(
-            'PackageIdentifier: OpenCLICollective.cfl'
-            'PackageVersion: 0.0.1'
-            'DefaultLocale: en-US'
-            'ManifestType: version'
-            'ManifestVersion: 1.6.0'
-          )
+          # Read actual templates and substitute placeholders for validation
+          Write-Host "Reading and processing actual template files..."
 
-          Set-Content "$testDir/OpenCLICollective.cfl.locale.en-US.yaml" -Encoding UTF8 @(
-            'PackageIdentifier: OpenCLICollective.cfl'
-            'PackageVersion: 0.0.1'
-            'PackageLocale: en-US'
-            'Publisher: Open CLI Collective'
-            'PublisherUrl: https://github.com/open-cli-collective'
-            'PackageName: Confluence CLI'
-            'PackageUrl: https://github.com/open-cli-collective/confluence-cli'
-            'License: MIT'
-            'LicenseUrl: https://github.com/open-cli-collective/confluence-cli/blob/main/LICENSE'
-            'ShortDescription: Command-line interface for Atlassian Confluence Cloud'
-            'ManifestType: defaultLocale'
-            'ManifestVersion: 1.6.0'
-          )
+          # Version manifest
+          $content = Get-Content "packaging/winget/OpenCLICollective.cfl.yaml" -Raw
+          $content = $content -replace "0\.0\.0", $testVersion
+          Set-Content "$testDir/OpenCLICollective.cfl.yaml" $content -Encoding UTF8
 
-          Set-Content "$testDir/OpenCLICollective.cfl.installer.yaml" -Encoding UTF8 @(
-            'PackageIdentifier: OpenCLICollective.cfl'
-            'PackageVersion: 0.0.1'
-            'InstallerType: zip'
-            'NestedInstallerType: portable'
-            'NestedInstallerFiles:'
-            '  - RelativeFilePath: cfl.exe'
-            '    PortableCommandAlias: cfl'
-            'Installers:'
-            '  - Architecture: x64'
-            '    InstallerUrl: https://github.com/open-cli-collective/confluence-cli/releases/download/v0.0.1/cfl_0.0.1_windows_amd64.zip'
-            '    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000001'
-            '  - Architecture: arm64'
-            '    InstallerUrl: https://github.com/open-cli-collective/confluence-cli/releases/download/v0.0.1/cfl_0.0.1_windows_arm64.zip'
-            '    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000002'
-            'ManifestType: installer'
-            'ManifestVersion: 1.6.0'
-          )
+          # Locale manifest
+          $content = Get-Content "packaging/winget/OpenCLICollective.cfl.locale.en-US.yaml" -Raw
+          $content = $content -replace "0\.0\.0", $testVersion
+          Set-Content "$testDir/OpenCLICollective.cfl.locale.en-US.yaml" $content -Encoding UTF8
 
-          Write-Host "Validating winget manifest schema..."
+          # Installer manifest (substitute version and checksums)
+          $content = Get-Content "packaging/winget/OpenCLICollective.cfl.installer.yaml" -Raw
+          $content = $content -replace "0\.0\.0", $testVersion
+          $regex = [regex]"0{64}"
+          $content = $regex.Replace($content, $testHash1, 1)
+          $content = $regex.Replace($content, $testHash2, 1)
+          Set-Content "$testDir/OpenCLICollective.cfl.installer.yaml" $content -Encoding UTF8
+
+          Write-Host "Generated test manifests:"
+          Get-ChildItem $testDir | ForEach-Object { Write-Host "  $_" }
+
+          Write-Host "`nValidating winget manifest schema..."
           winget validate --manifest $testDir/
           if ($LASTEXITCODE -ne 0) {
             Write-Error "Manifest schema validation failed"

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -103,5 +103,13 @@ jobs:
           Write-Host "Generated manifests:"
           Get-ChildItem $manifestDir | ForEach-Object { Write-Host "  $_" }
 
+          Write-Host "`nValidating manifests..."
+          winget validate --manifest $manifestDir
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Manifest validation failed"
+            exit 1
+          }
+          Write-Host "Validation passed!"
+
           Write-Host "`nSubmitting new package to Winget..."
           ./wingetcreate.exe submit --token ${{ secrets.WINGET_GITHUB_TOKEN }} $manifestDir

--- a/packaging/winget/OpenCLICollective.cfl.installer.yaml
+++ b/packaging/winget/OpenCLICollective.cfl.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 
 PackageIdentifier: OpenCLICollective.cfl
 PackageVersion: 0.0.0
@@ -15,4 +15,4 @@ Installers:
     InstallerUrl: https://github.com/open-cli-collective/confluence-cli/releases/download/v0.0.0/cfl_0.0.0_windows_arm64.zip
     InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0

--- a/packaging/winget/OpenCLICollective.cfl.locale.en-US.yaml
+++ b/packaging/winget/OpenCLICollective.cfl.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
 PackageIdentifier: OpenCLICollective.cfl
 PackageVersion: 0.0.0
@@ -24,4 +24,4 @@ Tags:
   - documentation
 ReleaseNotesUrl: https://github.com/open-cli-collective/confluence-cli/releases
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0

--- a/packaging/winget/OpenCLICollective.cfl.yaml
+++ b/packaging/winget/OpenCLICollective.cfl.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 
 PackageIdentifier: OpenCLICollective.cfl
 PackageVersion: 0.0.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.10.0

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -69,10 +69,10 @@ wingetcreate update OpenCLICollective.cfl --version <VERSION> --urls <x64_url> <
 
 ## Manifest Schema
 
-These manifests use schema version 1.6.0:
-- [Version manifest schema](https://aka.ms/winget-manifest.version.1.6.0.schema.json)
-- [Installer manifest schema](https://aka.ms/winget-manifest.installer.1.6.0.schema.json)
-- [Locale manifest schema](https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json)
+These manifests use schema version 1.10.0:
+- [Version manifest schema](https://aka.ms/winget-manifest.version.1.10.0.schema.json)
+- [Installer manifest schema](https://aka.ms/winget-manifest.installer.1.10.0.schema.json)
+- [Locale manifest schema](https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json)
 
 ## Installer Type
 


### PR DESCRIPTION
## Summary

Improves Winget manifest validation based on microsoft/winget-pkgs PR checklist requirements.

## Changes

### 1. Update schema version from 1.6.0 → 1.10.0

All manifest templates now use the latest schema version as recommended by microsoft/winget-pkgs.

### 2. Test workflow validates actual templates

Instead of hardcoded test manifests, `test-winget.yml` now:
- Reads actual template files from `packaging/winget/`
- Substitutes version and checksum placeholders
- Validates the result with `winget validate`

This ensures template changes are validated before merge.

### 3. Add validation before submit

Both `winget-publish.yml` and `release.yml` now run `winget validate --manifest` before submitting to catch issues early.

## Files Changed

| File | Change |
|------|--------|
| `packaging/winget/*.yaml` | Update ManifestVersion to 1.10.0 |
| `.github/workflows/test-winget.yml` | Use actual templates |
| `.github/workflows/winget-publish.yml` | Add validation step |
| `.github/workflows/release.yml` | Add validation step |
| `packaging/winget/README.md` | Update schema version refs |

Follow-up to #77