### PR TITLE
fix: address Chocolatey moderation issues

### DIFF
--- a/.github/workflows/chocolatey-publish.yml
+++ b/.github/workflows/chocolatey-publish.yml
@@ -26,12 +26,40 @@ jobs:
           }
           Write-Host "Found release v${{ inputs.version }}"
 
-      - name: Update version in nuspec
+      - name: Get checksums from release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "v${{ inputs.version }}" --pattern "checksums.txt" --dir .
+
+          $checksums = Get-Content checksums.txt
+          $x64Hash = ($checksums | Select-String "windows_amd64.zip").Line.Split()[0]
+          $arm64Hash = ($checksums | Select-String "windows_arm64.zip").Line.Split()[0]
+
+          Write-Host "x64 SHA256: $x64Hash"
+          Write-Host "arm64 SHA256: $arm64Hash"
+
+          echo "X64_HASH=$x64Hash" >> $env:GITHUB_ENV
+          echo "ARM64_HASH=$arm64Hash" >> $env:GITHUB_ENV
+
+      - name: Update version and checksums
         shell: pwsh
         run: |
+          $version = "${{ inputs.version }}"
+
+          # Update version in nuspec
           $nuspec = 'packaging/chocolatey/confluence-cli.nuspec'
-          (Get-Content $nuspec) -replace '<version>0.0.0</version>', "<version>${{ inputs.version }}</version>" | Set-Content $nuspec
-          Write-Host "Updated nuspec to version ${{ inputs.version }}"
+          (Get-Content $nuspec) -replace '<version>0.0.0</version>', "<version>$version</version>" | Set-Content $nuspec
+          Write-Host "Updated nuspec to version $version"
+
+          # Inject checksums into install script
+          $script = 'packaging/chocolatey/tools/chocolateyInstall.ps1'
+          $content = Get-Content $script -Raw
+          $content = $content -replace 'CHECKSUM_AMD64_PLACEHOLDER', $env:X64_HASH
+          $content = $content -replace 'CHECKSUM_ARM64_PLACEHOLDER', $env:ARM64_HASH
+          Set-Content $script $content
+          Write-Host "Injected checksums into install script"
 
       - name: Pack Chocolatey package
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,13 +35,40 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Update version in nuspec
+      - name: Get checksums from release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "${{ github.ref_name }}" --pattern "checksums.txt" --dir .
+
+          $checksums = Get-Content checksums.txt
+          $x64Hash = ($checksums | Select-String "windows_amd64.zip").Line.Split()[0]
+          $arm64Hash = ($checksums | Select-String "windows_arm64.zip").Line.Split()[0]
+
+          Write-Host "x64 SHA256: $x64Hash"
+          Write-Host "arm64 SHA256: $arm64Hash"
+
+          echo "X64_HASH=$x64Hash" >> $env:GITHUB_ENV
+          echo "ARM64_HASH=$arm64Hash" >> $env:GITHUB_ENV
+
+      - name: Update version and checksums
         shell: pwsh
         run: |
           $version = "${{ github.ref_name }}".TrimStart('v')
+
+          # Update version in nuspec
           $nuspec = 'packaging/chocolatey/confluence-cli.nuspec'
           (Get-Content $nuspec) -replace '<version>0.0.0</version>', "<version>$version</version>" | Set-Content $nuspec
           Write-Host "Updated nuspec to version $version"
+
+          # Inject checksums into install script
+          $script = 'packaging/chocolatey/tools/chocolateyInstall.ps1'
+          $content = Get-Content $script -Raw
+          $content = $content -replace 'CHECKSUM_AMD64_PLACEHOLDER', $env:X64_HASH
+          $content = $content -replace 'CHECKSUM_ARM64_PLACEHOLDER', $env:ARM64_HASH
+          Set-Content $script $content
+          Write-Host "Injected checksums into install script"
 
       - name: Pack Chocolatey package
         shell: pwsh

--- a/packaging/chocolatey/confluence-cli.nuspec
+++ b/packaging/chocolatey/confluence-cli.nuspec
@@ -7,7 +7,7 @@
     <authors>Open CLI Collective</authors>
     <owners>rianjs</owners>
     <licenseUrl>https://github.com/open-cli-collective/confluence-cli/blob/main/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/open-cli-collective/confluence-cli</projectUrl>
+    <projectUrl>https://github.com/open-cli-collective/confluence-cli#readme</projectUrl>
     <projectSourceUrl>https://github.com/open-cli-collective/confluence-cli</projectSourceUrl>
     <packageSourceUrl>https://github.com/open-cli-collective/confluence-cli/tree/main/packaging/chocolatey</packageSourceUrl>
     <bugTrackerUrl>https://github.com/open-cli-collective/confluence-cli/issues</bugTrackerUrl>

--- a/packaging/chocolatey/tools/chocolateyInstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyInstall.ps1
@@ -3,11 +3,17 @@ $ErrorActionPreference = 'Stop'
 $version = $env:ChocolateyPackageVersion
 $toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
 
+# Checksums injected by release workflow - DO NOT EDIT MANUALLY
+$checksumAmd64 = 'CHECKSUM_AMD64_PLACEHOLDER'
+$checksumArm64 = 'CHECKSUM_ARM64_PLACEHOLDER'
+
 # Architecture detection with ARM64 support
 if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') {
     $arch = 'arm64'
+    $checksum = $checksumArm64
 } elseif ([Environment]::Is64BitOperatingSystem) {
     $arch = 'amd64'
+    $checksum = $checksumAmd64
 } else {
     throw "32-bit Windows is not supported. confluence-cli requires 64-bit Windows."
 }
@@ -15,15 +21,6 @@ if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') {
 $baseUrl = "https://github.com/open-cli-collective/confluence-cli/releases/download/v${version}"
 $zipFile = "cfl_${version}_windows_${arch}.zip"
 $url = "${baseUrl}/${zipFile}"
-$checksumsUrl = "${baseUrl}/checksums.txt"
-
-# Fetch checksums and extract the one for our architecture
-$checksums = (Invoke-WebRequest -Uri $checksumsUrl -UseBasicParsing).Content
-$checksumLine = $checksums -split "`n" | Where-Object { $_ -match $zipFile }
-if (-not $checksumLine) {
-    throw "Could not find checksum for ${zipFile} in checksums.txt"
-}
-$checksum = ($checksumLine -split '\s+')[0]
 
 Write-Host "Installing confluence-cli ${version} for Windows ${arch}..."
 Write-Host "URL: ${url}"


### PR DESCRIPTION
## Summary
- Fix CPMR0041: Differentiate `projectUrl` from `projectSourceUrl` by appending `#readme`
- Fix CPMR0055: Remove `Invoke-WebRequest` custom downloader
- Fix CPMR0073: Inject checksums at build time instead of fetching at runtime

Checksums are now baked into the install script during release/publish workflows, eliminating the need to download `checksums.txt` at install time.

## Test plan
- [ ] Merge and trigger manual Chocolatey publish workflow
- [ ] Verify package passes Chocolatey moderation

Fixes #75