### PR TITLE
feat: add ATLASSIAN_* env var fallbacks for shared credentials

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,19 @@ type pageAPI interface {
 ### Integration Tests
 After significant code changes, run through the manual integration test suite in [integration-tests.md](integration-tests.md). These tests verify real-world behavior against a live Confluence instance and catch edge cases that unit tests miss.
 
+## Environment Variables
+
+Variables are checked in precedence order (first match wins):
+
+| Setting | Precedence |
+|---------|------------|
+| URL | `CFL_URL` → `ATLASSIAN_URL` → config |
+| Email | `CFL_EMAIL` → `ATLASSIAN_EMAIL` → config |
+| API Token | `CFL_API_TOKEN` → `ATLASSIAN_API_TOKEN` → config |
+| Default Space | `CFL_DEFAULT_SPACE` → config |
+
+Use `ATLASSIAN_*` for shared credentials across cfl and jtk. Use `CFL_*` to override per-tool.
+
 ## Undocumented Constants
 
 | Constant | Value | Location |

--- a/README.md
+++ b/README.md
@@ -651,14 +651,30 @@ output_format: table
 
 ### Environment Variables
 
-Environment variables override config file values:
+Environment variables override config file values. Variables are checked in order of precedence (first match wins):
 
-| Variable | Description |
-|----------|-------------|
-| `CFL_URL` | Confluence instance URL |
-| `CFL_EMAIL` | Your Atlassian email |
-| `CFL_API_TOKEN` | Your API token |
-| `CFL_DEFAULT_SPACE` | Default space key |
+| Setting | Precedence (highest to lowest) |
+|---------|-------------------------------|
+| URL | `CFL_URL` → `ATLASSIAN_URL` → config file |
+| Email | `CFL_EMAIL` → `ATLASSIAN_EMAIL` → config file |
+| API Token | `CFL_API_TOKEN` → `ATLASSIAN_API_TOKEN` → config file |
+| Default Space | `CFL_DEFAULT_SPACE` → config file |
+
+**Shared credentials:** If you use both `cfl` and `jtk` (Jira CLI), set `ATLASSIAN_*` variables once:
+
+```bash
+export ATLASSIAN_URL=https://mycompany.atlassian.net
+export ATLASSIAN_EMAIL=user@example.com
+export ATLASSIAN_API_TOKEN=your-api-token
+```
+
+**Per-tool override:** Use `CFL_*` to override for Confluence specifically:
+
+```bash
+export ATLASSIAN_EMAIL=user@example.com
+export ATLASSIAN_API_TOKEN=your-api-token
+export CFL_URL=https://confluence.internal.corp.com  # Different URL for Confluence
+```
 
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,19 +50,28 @@ func (c *Config) NormalizeURL() {
 
 // LoadFromEnv loads configuration from environment variables.
 // Environment variables override existing values only if set and non-empty.
+// Precedence: CFL_* → ATLASSIAN_* → existing config value
 func (c *Config) LoadFromEnv() {
-	if url := os.Getenv("CFL_URL"); url != "" {
+	if url := getEnvWithFallback("CFL_URL", "ATLASSIAN_URL"); url != "" {
 		c.URL = url
 	}
-	if email := os.Getenv("CFL_EMAIL"); email != "" {
+	if email := getEnvWithFallback("CFL_EMAIL", "ATLASSIAN_EMAIL"); email != "" {
 		c.Email = email
 	}
-	if token := os.Getenv("CFL_API_TOKEN"); token != "" {
+	if token := getEnvWithFallback("CFL_API_TOKEN", "ATLASSIAN_API_TOKEN"); token != "" {
 		c.APIToken = token
 	}
 	if space := os.Getenv("CFL_DEFAULT_SPACE"); space != "" {
 		c.DefaultSpace = space
 	}
+}
+
+// getEnvWithFallback returns the value of the primary env var, or the fallback if primary is empty.
+func getEnvWithFallback(primary, fallback string) string {
+	if v := os.Getenv(primary); v != "" {
+		return v
+	}
+	return os.Getenv(fallback)
 }
 
 // DefaultConfigPath returns the default configuration file path.


### PR DESCRIPTION
## Summary

- Add `ATLASSIAN_URL`, `ATLASSIAN_EMAIL`, `ATLASSIAN_API_TOKEN` env var fallbacks
- Enables shared credentials between cfl (Confluence) and jtk (Jira) CLIs
- Tool-specific vars (`CFL_*`) take precedence over shared vars (`ATLASSIAN_*`)

## Precedence Order

| Setting | Lookup Order |
|---------|-------------|
| URL | `CFL_URL` → `ATLASSIAN_URL` → config |
| Email | `CFL_EMAIL` → `ATLASSIAN_EMAIL` → config |
| Token | `CFL_API_TOKEN` → `ATLASSIAN_API_TOKEN` → config |

## Usage

**Shared credentials (both tools):**
```bash
export ATLASSIAN_URL=https://mycompany.atlassian.net
export ATLASSIAN_EMAIL=user@example.com
export ATLASSIAN_API_TOKEN=your-token
```

**Per-tool override:**
```bash
export ATLASSIAN_EMAIL=user@example.com
export ATLASSIAN_API_TOKEN=your-token
export CFL_URL=https://confluence.internal.corp.com  # Different URL for Confluence only
```

## Changes

- `internal/config/config.go`: Add `getEnvWithFallback()` helper, update `LoadFromEnv()`
- `internal/config/config_test.go`: Add tests for fallback behavior and precedence
- `README.md`, `CLAUDE.md`: Document new env vars

## Test Plan

- [x] Build passes
- [x] All tests pass (including new ATLASSIAN_* tests)
- [x] Lint passes

Closes #99