### PR TITLE
docs: add secure token storage examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,34 @@ export ATLASSIAN_API_TOKEN=your-api-token
 export CFL_URL=https://confluence.internal.corp.com  # Different URL for Confluence
 ```
 
+### Secure Token Storage
+
+Your API token is sensitive. Rather than storing it in a config file, we recommend using environment variables with a secret manager:
+
+**1Password CLI:**
+
+```bash
+# In your .zshrc or .bashrc
+export ATLASSIAN_API_TOKEN="$(op read 'op://Vault/Atlassian API Token/password')"
+```
+
+**macOS Keychain:**
+
+```bash
+# Store token
+security add-generic-password -s "atlassian-api" -a "api_token" -w "your-token-here"
+
+# Retrieve in shell config
+export ATLASSIAN_API_TOKEN="$(security find-generic-password -s 'atlassian-api' -a 'api_token' -w)"
+```
+
+**Windows Credential Manager:**
+
+```powershell
+# Store
+cmdkey /generic:atlassian-api /user:api_token /pass:your-token-here
+```
+
 ---
 
 ## Output Formats


### PR DESCRIPTION
## Summary

- Add secure token storage examples to the Environment Variables section of the README
- Documents 1Password CLI, macOS Keychain, and Windows Credential Manager approaches
- The code changes for env var standardization (ATLASSIAN_* fallbacks) were already shipped in #100

Fixes #93